### PR TITLE
fix(deps): bump jose to ^6, require Node >=18; v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "docs:api": "node scripts/gen-api-docs.js"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "bugs": {
     "url": "https://github.com/flic/node-red-contrib-hal2/issues"
@@ -41,7 +41,7 @@
     }
   },
   "dependencies": {
-    "jose": "^4.15.5"
+    "jose": "^6.2.3"
   },
   "optionalDependencies": {
     "better-sqlite3": "^12.11.1"


### PR DESCRIPTION
Node-RED flow-library scorecard flagged an outdated dependency: jose was pinned at ^4.15.5 (latest 6.2.3, two majors behind). hal2 only uses createRemoteJWKSet + jwtVerify, both unchanged across v4-v6, and jose still ships a CommonJS build, so the bump is low-risk. jose v5+ needs Node 18+ (Web Crypto), which Node-RED 5 already provides — also move engines.node to
>=18 (was the stale >=14). Verified a sign/verify round-trip on jose 6.2.3.