### PR TITLE
MCP access gates: claim values, read/write split, ported hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,38 @@ The **hal2EventHandler** config node can run an embedded **MCP (Model Context Pr
 
 It ships with a catalog of built-in tools:
 
-- **Read** — `get_all_states`, `get_state`, `get_history`, `get_scenes`, `get_presence`, `get_alerts`
-- **Control** — `set_light`, `control_device`, `control_fan`, `control_cover`, `control_spa`, `control_climate`, `activate_scene`
-- **Analyse** — `analyze_patterns`
+- **Read** — `get_all_states`, `get_state`, `get_history`, `get_scenes`, `get_presence`, `get_alerts`, `analyze_patterns`
+- **Write** — `set_light`, `control_device`, `control_fan`, `control_cover`, `control_spa`, `control_climate`, `activate_scene`
 - **Admin** (opt-in) — `get_flow`, `deploy_flow`
+
+Those three classes are also the unit of [access control](#access-control): a token can be allowed to read the house without being allowed to change it.
 
 Tools are exposed only when matching hardware is configured at that location — a server with no covers won't advertise `control_cover`. Things and Items can carry free-text **notes** and **tags**, and devices report derived **categories** (light, fan, cover, climate, spa, scene), all of which help the assistant pick the right device. Full parameters and examples are in **[docs/API.md](docs/API.md)**.
 
 ### Access control
 
-Two independent, optional gates. Each is a **claim** + **value** pair: an array claim must *contain* the value, a scalar claim must *equal* it, and an empty value leaves the gate open to any authenticated caller.
+Tools are gated on the **claims in the caller's verified access token**, so one MCP endpoint can serve several people at different privilege levels. A gate is a **claim name** plus a **value list**: the values are comma-separated and matched **any-of** — an array claim must *contain* at least one of them, a scalar claim must *equal* one. An **empty list is no constraint**, which is the default everywhere, so an existing setup keeps behaving exactly as before.
 
-- **Admin-tools gate** (Event handler → *MCP* tab, `Required claim`/`Required value`): gates only the admin tools (`get_flow`, `deploy_flow`). Ordinary read/control tools stay available to any authenticated caller. Defaults to claim `groups`, value `admin`.
-- **Standalone-server gate** (a `hal2MCPServer` node in *Standalone* mode, `Required claim`/`Required value`): gates a whole standalone MCP server. Callers who fail the check still connect (`initialize` succeeds) but see no tools, and any `tools/call` is refused. Defaults to empty — all authenticated users allowed.
+On the Event handler's *MCP* tab, one **Access claim** (default `groups`) carries three lists, checked with **AND**:
 
-Both denials come back as an MCP tool result with `isError: true` and a human-readable reason, so the calling model is told *why* instead of getting a generic "tool execution failed".
+| Gate | Covers | Default |
+|---|---|---|
+| **Read tools** | `get_all_states`, `get_state`, `get_history`, `get_scenes`, `get_presence`, `get_alerts`, `analyze_patterns` | empty — any authenticated caller |
+| **Write tools** | `set_light`, `control_device`, `control_fan`, `control_cover`, `control_spa`, `control_climate`, `activate_scene` | empty — same as read |
+| **Admin tools** | `get_flow`, `deploy_flow` (and only when *Enable Node-RED admin tools* is on) | `admin` |
+
+The read list is the floor: a caller who fails it reaches nothing at all. Writes are checked **on top of** it, so `Read tools = family`, `Write tools = ops` gives the whole household visibility while only ops can switch anything. A tool that is in neither set — a future addition, or the undocumented `control_light` alias of `set_light` — is treated as a **write**, so an unclassified tool fails closed rather than slipping through.
+
+Two further gates layer on the custom-tool side:
+
+- **Standalone-server gate** (`hal2MCPServer` in *Standalone* mode, `Required claim`/`Required value`): gates a whole standalone MCP server and its own claim name, independent of the Event handler's.
+- **Per-tool gate** (`hal2MCPIn`, `Tool access`): narrows a single tool further, checked on top of its server's list.
+
+Callers who fail a gate still connect — `initialize` succeeds — but the tools they cannot use are **absent from `tools/list`**, so an assistant is never offered a tool it will then be refused. A direct call to a hidden tool comes back as an MCP tool result with `isError: true` and a human-readable reason, so the model is told *why* rather than getting a generic "tool execution failed".
+
+> The gates apply to the **MCP surface only**, where claims are cryptographically verified. The `hal2Api` node reads `msg.claims` off the message, which any flow can set, so gating it would be decoration rather than a boundary; it keeps its own local *Allow admin tools* checkbox instead.
+>
+> Claim names are matched as literal keys — a nested path such as `realm_access.roles` is not traversed. Fine for PocketID's flat `groups`; worth checking before pointing hal2 at Keycloak.
 
 ### Hostname filtering
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Callers who fail a gate still connect — `initialize` succeeds — but the tool
 
 > The gates apply to the **MCP surface only**, where claims are cryptographically verified. The `hal2Api` node reads `msg.claims` off the message, which any flow can set, so gating it would be decoration rather than a boundary; it keeps its own local *Allow admin tools* checkbox instead.
 >
-> Claim names are matched as literal keys — a nested path such as `realm_access.roles` is not traversed. Fine for PocketID's flat `groups`; worth checking before pointing hal2 at Keycloak.
+> **Nested claims** are addressed with a dotted path, for providers that don't put roles at the top level of the token: `realm_access.roles` reads Keycloak's realm roles, and any depth works. A key that exists literally always wins, so PocketID's flat `groups` is unaffected. Only strings and arrays of strings match — pointing the claim at a container object grants nothing rather than matching by accident.
 
 ### Hostname filtering
 

--- a/core/eventhandler.html
+++ b/core/eventhandler.html
@@ -178,7 +178,8 @@
                     <input type="text" id="node-config-input-writeRequiredValue" placeholder="(empty = same as read)" style="width:calc(100% - 185px)">
                 </div>
                 <div class="form-tips" style="margin-left:150px; margin-bottom:8px;">
-                    <small>One claim, one comma-separated <b>any-of</b> list per class, combined with <b>AND</b>.
+                    <small>One claim (a dotted path such as <code>realm_access.roles</code> reaches a nested one),
+                    one comma-separated <b>any-of</b> list per class, combined with <b>AND</b>.
                     <b>Read tools</b> observe (<code>get_state</code>, <code>get_history</code>, <code>get_presence</code>…);
                     <b>write tools</b> change the house (<code>set_light</code>, <code>control_cover</code>,
                     <code>activate_scene</code>…). A write also has to clear the read list, so

--- a/core/eventhandler.html
+++ b/core/eventhandler.html
@@ -153,8 +153,39 @@
                 <hr style="margin:12px 0">
 
                 <div class="form-row">
+                    <label for="node-config-input-localDebugGroups" style="width:150px"><i class="fa fa-users"></i> Debug groups</label>
+                    <input type="text" id="node-config-input-localDebugGroups" placeholder="admin" style="width:calc(100% - 185px)">
+                </div>
+                <div class="form-tips" style="margin-left:150px; margin-bottom:8px;">
+                    <small>Comma-separated <code>groups</code> claim granted to the debug token's user (default <code>admin</code>), so the access gates below can be exercised locally without a real identity provider. Only meaningful when the access claim below is <code>groups</code>.</small>
+                </div>
+                <div class="form-row">
                     <label for="node-config-input-tokenCacheTTL" style="width:150px"><i class="fa fa-clock-o"></i> Token cache TTL</label>
                     <input type="number" id="node-config-input-tokenCacheTTL" style="width:80px" min="30" value="300"> seconds
+                </div>
+                <hr style="margin:12px 0">
+
+                <div class="form-row">
+                    <label for="node-config-input-adminRequiredClaim" style="width:150px"><i class="fa fa-user-secret"></i> Access claim</label>
+                    <input type="text" id="node-config-input-adminRequiredClaim" placeholder="groups" style="width:calc(100% - 185px)">
+                </div>
+                <div class="form-row">
+                    <label for="node-config-input-readRequiredValue" style="width:150px"><i class="fa fa-eye"></i> Read tools</label>
+                    <input type="text" id="node-config-input-readRequiredValue" placeholder="(empty = any authenticated user)" style="width:calc(100% - 185px)">
+                </div>
+                <div class="form-row">
+                    <label for="node-config-input-writeRequiredValue" style="width:150px"><i class="fa fa-bolt"></i> Write tools</label>
+                    <input type="text" id="node-config-input-writeRequiredValue" placeholder="(empty = same as read)" style="width:calc(100% - 185px)">
+                </div>
+                <div class="form-tips" style="margin-left:150px; margin-bottom:8px;">
+                    <small>One claim, one comma-separated <b>any-of</b> list per class, combined with <b>AND</b>.
+                    <b>Read tools</b> observe (<code>get_state</code>, <code>get_history</code>, <code>get_presence</code>…);
+                    <b>write tools</b> change the house (<code>set_light</code>, <code>control_cover</code>,
+                    <code>activate_scene</code>…). A write also has to clear the read list, so
+                    read&nbsp;=&nbsp;<code>family</code> and write&nbsp;=&nbsp;<code>ops</code> lets the family look
+                    but only ops act. Both empty is the default and leaves every tool open to any authenticated
+                    caller. Applies to the MCP endpoint only — the hal2Api node is a local flow node and is not
+                    gated by these.</small>
                 </div>
                 <hr style="margin:12px 0">
 
@@ -173,20 +204,19 @@
                         <input type="number" id="node-config-input-adminPort" style="width:80px" min="1" max="65535" value="1880">
                     </div>
                     <div class="form-row">
-                        <label for="node-config-input-adminRequiredClaim" style="width:150px"><i class="fa fa-user-secret"></i> Required claim</label>
-                        <input type="text" id="node-config-input-adminRequiredClaim" placeholder="groups" style="width:calc(100% - 185px)">
-                    </div>
-                    <div class="form-row">
-                        <label for="node-config-input-adminRequiredValue" style="width:150px"><i class="fa fa-check"></i> Required value</label>
+                        <label for="node-config-input-adminRequiredValue" style="width:150px"><i class="fa fa-check"></i> Admin tools</label>
                         <input type="text" id="node-config-input-adminRequiredValue" placeholder="admin" style="width:calc(100% - 185px)">
                     </div>
                     <div class="form-tips" style="margin-left:150px; margin-bottom:8px;">
-                        <small>The JWT claim (default <code>groups</code>) must contain the value (default <code>admin</code>) for the admin tools to be callable. Leave the value empty to allow all authenticated users.</small>
+                        <small>A comma-separated any-of list against the <b>Access claim</b> above, defaulting to
+                        <code>admin</code>. Leave it empty to allow any authenticated user. Unlike the read and write
+                        lists this one also guards the hal2Api node, which must present claims to reach admin tools
+                        at all.</small>
                     </div>
                     <div class="form-row" style="background:#fff8e1; border:1px solid #ffe082; border-radius:4px; padding:8px 12px; margin-top:4px;">
                         <i class="fa fa-info-circle" style="color:#f9a825;"></i>
                         <span style="font-size:12px; margin-left:6px;">
-                            Enabled admin tools: <strong>get_flows</strong>, <strong>get_flow</strong>, <strong>deploy_flow</strong>.<br>
+                            Enabled admin tools: <strong>get_flow</strong>, <strong>deploy_flow</strong>.<br>
                             These call the Node-RED admin API on localhost:&lt;port&gt;.
                         </span>
                     </div>
@@ -232,8 +262,10 @@
     <li><strong>MCP server</strong>: an embedded, OAuth-protected <a href="https://modelcontextprotocol.io" target="_blank">Model Context Protocol</a>
     server that exposes the device tool catalog to AI assistants such as Claude. Works with any
     standard OIDC identity provider (endpoints auto-discovered), carries a per-location identifier,
-    and supports a local debug token. Admin tools (<code>get_flow</code>/<code>deploy_flow</code>) are
-    opt-in.</li>
+    and supports a local debug token. Callers can be gated per tool class — one claim, an any-of
+    value list each for read tools, write tools and the opt-in admin tools
+    (<code>get_flow</code>/<code>deploy_flow</code>) — so a token may be allowed to observe the house
+    without being allowed to change it.</li>
     <li><strong>Heartbeat</strong>: per-thing liveness tracking surfaced as the <code>alive</code>
     flag in <code>get_all_states</code>.</li>
 
@@ -295,8 +327,11 @@
             tokenCacheTTL:     { value: 300 },
             adminToolsEnabled: { value: false },
             adminPort:         { value: 1880 },
+            localDebugGroups:  { value: 'admin' },
             adminRequiredClaim:{ value: 'groups' },
             adminRequiredValue:{ value: 'admin' },
+            readRequiredValue: { value: '' },
+            writeRequiredValue:{ value: '' },
             // Shared function libraries
             ingressLibrary:    { value: [], required: false },
             egressLibrary:     { value: [], required: false }

--- a/core/eventhandler.js
+++ b/core/eventhandler.js
@@ -546,9 +546,16 @@ module.exports = function(RED) {
 
             // ── MCP auth (OIDC discovery, JWKS, token validation, Bearer middleware) ──
             // See core/mcp-auth.js. External deps injected so the module stays testable.
+            // Groups granted to the local debug token (comma-separated, default 'admin'), so gates
+            // with other values can be tested locally. Default only when never set — an explicitly
+            // emptied field means a debug user with no groups at all.
+            const localDebugGroups = (config.localDebugGroups === undefined ? 'admin' : config.localDebugGroups)
+                .split(',').map(s => s.trim()).filter(Boolean);
+
             const auth = createMcpAuth({
                 issuerUrl, tokenTTL, tokenAudience, mcpServerUrl: publicBase,
                 localDebugToken: (node.credentials && node.credentials.localDebugToken) || '',
+                localDebugGroups,
                 httpGet,
                 log:  msg => node.log(msg),
                 warn: msg => node.warn(msg)

--- a/core/eventhandler.js
+++ b/core/eventhandler.js
@@ -7,9 +7,10 @@ const { createMcpAuth } = require('./mcp-auth');
 const { createHttpGuards, hostFilter } = require('../lib/httpGuards');
 
 const {
-    MCP_TOOLS, MCP_TOOLS_ADMIN, MCP_ADMIN_TOOL_NAMES,
+    MCP_TOOLS, MCP_TOOLS_ADMIN, MCP_ADMIN_TOOL_NAMES, toolClass,
     TOOL_HARDWARE_REQUIREMENTS, expandHaTypeFilter, deriveCategories
 } = require('./mcp-tools');
+const { createToolGate, claimAllows } = require('../lib/claim-gate');
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
@@ -85,8 +86,11 @@ module.exports = function(RED) {
 
         // ── Dynamic MCP tool registry (used by hal2MCPIn / hal2MCPOut) ─────────
 
-        node.mcpRegisteredTools = {};
-        node.mcpPendingCalls    = {};
+        // Null-prototype: tool names arrive from remote callers in tools/call, and a plain
+        // {} resolves names like "__proto__" or "constructor" through the prototype chain —
+        // past the "Unknown tool" check and into a listener-less 30 s hang.
+        node.mcpRegisteredTools = Object.create(null);
+        node.mcpPendingCalls    = Object.create(null);
 
         // ── Shared function library lookup helpers ────────────────────────────
 
@@ -97,12 +101,29 @@ module.exports = function(RED) {
             return (node.egressLibrary || []).find(f => f.id === id);
         };
 
-        node.registerMCPTool = function (toolName, description, schema, timeoutSec) {
-            node.mcpRegisteredTools[toolName] = { description, schema, timeoutMs: (timeoutSec || 30) * 1000 };
+        node.registerMCPTool = function (toolName, description, schema, timeoutSec, requiredValue, ownerId) {
+            // Duplicate names are a silent conflict: the registry entry is overwritten but
+            // BOTH hal2MCPIn listeners keep firing, so one call runs two flows and whichever
+            // hal2MCPOut answers first wins. Say so rather than debug it in production.
+            const existing = node.mcpRegisteredTools[toolName];
+            if (existing && existing.ownerId !== ownerId) {
+                node.warn('MCP tool "' + toolName + '" is registered by more than one hal2MCPIn node — '
+                    + 'each call will run every one of those flows, with unpredictable results. '
+                    + 'Rename the tools so each name is unique.');
+            }
+            node.mcpRegisteredTools[toolName] = {
+                description, schema, timeoutMs: (timeoutSec || 30) * 1000,
+                requiredValue: requiredValue || '', ownerId
+            };
             node.log('MCP tool registered: ' + toolName);
         };
 
-        node.unregisterMCPTool = function (toolName) {
+        node.unregisterMCPTool = function (toolName, ownerId) {
+            // Only the registering node may remove its entry — when two hal2MCPIn nodes
+            // collide on a name, deleting the loser must not tear down the survivor.
+            const entry = node.mcpRegisteredTools[toolName];
+            if (!entry) { return; }
+            if (ownerId !== undefined && entry.ownerId !== undefined && entry.ownerId !== ownerId) { return; }
             delete node.mcpRegisteredTools[toolName];
             node.log('MCP tool unregistered: ' + toolName);
         };
@@ -483,12 +504,37 @@ module.exports = function(RED) {
             const adminPort     = Number(config.adminPort || 1880);
             const mcpScopesStr  = (config.mcpScopes || 'openid profile email').trim();
             const mcpScopesArr  = mcpScopesStr.split(/\s+/).filter(Boolean);
-            const adminClaim    = (config.adminRequiredClaim || 'groups').trim();
+            const gateClaim     = (config.adminRequiredClaim || 'groups').trim();
             // Default 'admin' only when never set (undefined). Empty string is respected
             // as "allow any authenticated user" per the UI help text.
             const adminValue    = (config.adminRequiredValue === undefined ? 'admin' : config.adminRequiredValue).trim();
+            // Read and write default to empty — no constraint — so an existing install
+            // behaves exactly as before until the fields are filled in.
+            const readValue     = (config.readRequiredValue  || '').trim();
+            const writeValue    = (config.writeRequiredValue || '').trim();
 
-            const isAdmin = claims => common.claimSatisfied(claims, adminClaim, adminValue);
+            // Admin keeps its own check inside dispatchAdminTools, where it also guards the
+            // hal2Api path — only the matcher changes, so a single value still behaves as
+            // before while comma-separated lists now work too.
+            const isAdmin = claims => claimAllows(claims, gateClaim, adminValue);
+
+            // Read/write authorization for the MCP surface. Built once per request from
+            // verified claims and handed to callTool in opts — deliberately not derived from
+            // `claims` inside callTool, because hal2Api supplies unverified msg.claims and
+            // must not be able to self-grant. No opts.gate means no read/write gating, which
+            // is exactly the local-flow case.
+            function buildGate(claims) {
+                const gate = createToolGate({ claims, claimName: gateClaim, serverValue: readValue });
+                return {
+                    // Every tool must clear the read list; writes must clear both.
+                    allows(toolName) {
+                        if (!gate.serverGranted) { return false; }
+                        return toolClass(toolName) === 'write' ? gate.allows(writeValue) : true;
+                    },
+                    // Dynamic hal2MCPIn tools carry their own list instead of a class.
+                    allowsValue: list => gate.allows(list)
+                };
+            }
 
             // ── Admin API helper ───────────────────────────────────────────────
 
@@ -1505,6 +1551,21 @@ module.exports = function(RED) {
                 return toolOk(JSON.stringify(notConfigured));
             }
 
+            // Read/write gating, only when the caller supplied a gate — i.e. the MCP route,
+            // where the claims behind it were actually verified. Admin tools carry their own
+            // check inside dispatchAdminTools and are skipped here.
+            if (opts.gate && !MCP_ADMIN_TOOL_NAMES.has(toolName)) {
+                const dynamic = node.mcpRegisteredTools[toolName];
+                const allowed = dynamic
+                    ? opts.gate.allowsValue(dynamic.requiredValue)
+                    : opts.gate.allows(toolName);
+                if (!allowed) {
+                    node.status({ fill: 'red', shape: 'ring', text: 'forbidden' });
+                    return rpcErr(-32000, 'Access denied: the "' + toolName + '" tool requires a permission '
+                        + 'your token does not have. This is a permission restriction, not a tool error.');
+                }
+            }
+
             let r;
             r = await dispatchReadTools(toolName, args, claims, opts);    if (r !== undefined) return r;
             r = await dispatchControlTools(toolName, args, claims, opts); if (r !== undefined) return r;
@@ -1624,6 +1685,9 @@ module.exports = function(RED) {
                 const claims = await requireBearer(req, res);
                 if (!claims) return;
 
+                // One authorization decision per request, from claims this route verified.
+                const gate = buildGate(claims);
+
                 const body   = req.body || {};
                 const id     = body.id     !== undefined ? body.id : null;
                 const method = body.method || null;
@@ -1647,7 +1711,7 @@ module.exports = function(RED) {
                                           'scene status can change at any time. When in doubt, call get_all_states ' +
                                           'or the relevant tool again before answering. ' +
                                           'Available tools: ' + [
-                                              ...MCP_TOOLS.filter(t => !getNotConfiguredError(t.name)),
+                                              ...MCP_TOOLS.filter(t => !getNotConfiguredError(t.name) && gate.allows(t.name)),
                                               ...(adminEnabled && isAdmin(claims) ? MCP_TOOLS_ADMIN : [])
                                           ].map(t => t.name).join(', ') + '.'
                     });
@@ -1659,9 +1723,12 @@ module.exports = function(RED) {
 
                 // ── tools/list ────────────────────────────────────────────────
                 if (method === 'tools/list') {
-                    const tools = MCP_TOOLS.filter(t => !getNotConfiguredError(t.name));
+                    // Filtered rather than listed-then-refused: a tool the caller cannot use
+                    // should not appear, or the model wastes turns discovering it is barred.
+                    const tools = MCP_TOOLS.filter(t => !getNotConfiguredError(t.name) && gate.allows(t.name));
                     if (adminEnabled && isAdmin(claims)) tools.push(...MCP_TOOLS_ADMIN);
                     for (const [name, t] of Object.entries(node.mcpRegisteredTools)) {
+                        if (!gate.allowsValue(t.requiredValue)) { continue; }
                         const s = t.schema;
                         const inputSchema = (s && s.type === 'object')
                             ? s
@@ -1674,7 +1741,8 @@ module.exports = function(RED) {
                 // ── tools/call ────────────────────────────────────────────────
                 if (method === 'tools/call') {
                     node.status({ fill: 'blue', shape: 'dot', text: params.name });
-                    const out = await node.callTool(params.name, params.arguments || {}, claims, { adminEnabled: adminEnabled });
+                    const out = await node.callTool(params.name, params.arguments || {}, claims,
+                        { adminEnabled: adminEnabled, gate: gate });
                     node.status({ fill: out.ok ? 'green' : 'red', shape: 'dot', text: out.ok ? 'ready' : 'error' });
                     if (out.ok && out.content) return respond({ content: out.content });
                     if (out.ok)                return toolOk(out.text);

--- a/core/mcp-auth.js
+++ b/core/mcp-auth.js
@@ -23,6 +23,7 @@ function createMcpAuth(opts) {
         tokenTTL           = 300000,
         tokenAudience      = '',
         localDebugToken    = '',
+        localDebugGroups   = ['admin'],
         mcpServerUrl       = '',
         discoveryRetryMs   = 30000,
         httpGet,
@@ -115,9 +116,11 @@ function createMcpAuth(opts) {
 
     async function validateToken(token) {
         // Local debug token bypass — skips the IdP entirely. Constant-time compare so the token
-        // can't be recovered by timing the response.
+        // can't be recovered by timing the response. Groups are configurable so claim gates with
+        // values other than 'admin' can be exercised locally too; sliced so a flow that mutates
+        // msg.jwtClaims can't poison later requests.
         if (localDebugToken && secretEqual(token, localDebugToken)) {
-            return { sub: 'debug', name: 'Local debug user', groups: ['admin'] };
+            return { sub: 'debug', name: 'Local debug user', groups: localDebugGroups.slice() };
         }
 
         const cacheKey = 'auth_' + crypto.createHash('sha256').update(token).digest('hex').slice(0, 20);

--- a/core/mcp-tools.js
+++ b/core/mcp-tools.js
@@ -337,10 +337,39 @@ const MCP_TOOLS_ADMIN = [
 
 const MCP_ADMIN_TOOL_NAMES = new Set(MCP_TOOLS_ADMIN.map(t => t.name));
 
+// Which built-in tools only observe, and which change the house. The split cannot be
+// derived from the dispatch functions in eventhandler.js — get_scenes and get_alerts are
+// read-only but are handled inside dispatchControlTools — so it has to be stated here.
+const MCP_READ_TOOL_NAMES = new Set([
+    'get_all_states', 'get_state', 'get_history',
+    'get_scenes', 'get_presence', 'get_alerts', 'analyze_patterns'
+]);
+
+const MCP_WRITE_TOOL_NAMES = new Set([
+    'set_light',
+    // control_light is an undocumented alias of set_light accepted by the dispatcher but
+    // absent from MCP_TOOLS. Leaving it out would be a clean bypass of the write gate.
+    'control_light',
+    'control_device', 'control_fan', 'control_cover', 'control_spa', 'control_climate',
+    'activate_scene'
+]);
+
+// Which gate a built-in tool answers to. Anything unclassified counts as a write, so a tool
+// added to the catalog without being classified is held to the stricter gate rather than
+// slipping through ungated; test/mcp-tools.test.js turns the omission into a build failure.
+function toolClass(name) {
+    if (MCP_ADMIN_TOOL_NAMES.has(name)) { return 'admin'; }
+    if (MCP_READ_TOOL_NAMES.has(name))  { return 'read'; }
+    return 'write';
+}
+
 module.exports = {
     MCP_TOOLS,
     MCP_TOOLS_ADMIN,
     MCP_ADMIN_TOOL_NAMES,
+    MCP_READ_TOOL_NAMES,
+    MCP_WRITE_TOOL_NAMES,
+    toolClass,
     TOOL_HARDWARE_REQUIREMENTS,
     HA_TYPE_GROUPS,
     expandHaTypeFilter,

--- a/core/mcpin.html
+++ b/core/mcpin.html
@@ -27,6 +27,18 @@
         <label for="node-input-timeout"><i class="fa fa-clock-o"></i> Timeout</label>
         <input type="number" id="node-input-timeout" style="width:80px" min="1" value="30"> seconds
     </div>
+    <hr style="margin:12px 0">
+
+    <div class="form-row">
+        <label for="node-input-requiredValue"><i class="fa fa-check"></i> Tool access</label>
+        <input type="text" id="node-input-requiredValue" placeholder="(empty = no extra restriction)" style="width:calc(100% - 105px)">
+    </div>
+    <div class="form-tips" style="margin-left:105px; margin-bottom:8px;">
+        <small>Per-tool access gate. Comma-separated values of the MCP Server node's <b>Required claim</b> (<span id="hal2-mcp-in-claim-name"><code>groups</code></span>) — the caller's claim must contain <b>at least one</b> of them for this tool to be listed or callable. Applied <b>on top of</b> that server's own <b>Required value</b> list, not instead of it: callers must clear both.</small>
+    </div>
+
+    <hr style="margin:12px 0">
+
     <div class="form-row">
         <label for="node-input-exposeClaims" style="width:auto"><i class="fa fa-id-card-o"></i> Expose JWT claims</label>
         <input type="checkbox" id="node-input-exposeClaims" style="width:23px; margin:0">
@@ -78,6 +90,7 @@
             inputSchema : { value: '' },
             topic       : { value: '' },
             timeout     : { value: 30 },
+            requiredValue: { value: '' },
             exposeClaims: { value: false }
         },
         inputs    : 0,
@@ -86,6 +99,16 @@
         paletteLabel: 'MCP In',
         label     : function () { return this.name || this.toolName || 'MCP In'; },
         oneditprepare: function () {
+            // Show the selected server's actual claim name in the Tool access tip — the values
+            // typed here are values *of that claim*, and it is configured on a different node.
+            function updateClaimName() {
+                var server = RED.nodes.node($('#node-input-mcpServer').val());
+                var claim  = (server && server.requiredClaim) || 'groups';
+                $('#hal2-mcp-in-claim-name').html($('<code>').text(claim));
+            }
+            $('#node-input-mcpServer').on('change', updateClaimName);
+            updateClaimName();
+
             if (!this.inputSchema) {
                 $('#node-input-inputSchema').val(JSON.stringify({
                     type: 'object',

--- a/core/mcpin.js
+++ b/core/mcpin.js
@@ -23,7 +23,10 @@ module.exports = function (RED) {
             schema = { type: 'object', properties: {} };
         }
 
-        mcpServer.registerMCPTool(toolName, config.description, schema, timeoutSec);
+        // Per-tool gate: a comma-separated any-of list against the server's claim, on top of
+        // the server-wide list. Empty means the tool adds no constraint of its own.
+        mcpServer.registerMCPTool(toolName, config.description, schema, timeoutSec,
+            (config.requiredValue || '').trim(), node.id);
 
         const exposeClaims = config.exposeClaims === true;
 
@@ -43,7 +46,7 @@ module.exports = function (RED) {
         node.status({ fill: 'green', shape: 'dot', text: 'ready' });
 
         node.on('close', function () {
-            mcpServer.unregisterMCPTool(toolName);
+            mcpServer.unregisterMCPTool(toolName, node.id);
             mcpServer.removeListener('mcp_tool_' + toolName, node.listener);
         });
     }

--- a/core/mcpserver.html
+++ b/core/mcpserver.html
@@ -32,7 +32,10 @@
         <input type="text" id="node-config-input-requiredValue" placeholder="(empty = any authenticated user)" style="width:calc(100% - 105px)">
     </div>
     <div class="form-tips" id="row-required-tip" style="margin-left:105px; margin-bottom:8px;">
-        <small>The JWT claim (default <code>groups</code>) must contain the value for this server's tools to be callable. Leave the value empty to allow all authenticated users.</small>
+        <small>The caller's JWT claim (default <code>groups</code>) must contain <b>at least one</b> of the
+        comma-separated values for this server's tools to be listed or callable. Leave the value empty
+        to allow all authenticated users. Individual <code>hal2MCPIn</code> nodes can narrow this further
+        with their own <b>Tool access</b> list, which is checked on top of this one.</small>
     </div>
 </script>
 
@@ -52,10 +55,11 @@
     endpoint. Multiple standalone <code>hal2MCPServer</code> nodes can share one Event handler,
     each with a different path.</p>
     <p>Standalone mode also exposes an optional <b>Required claim</b>/<b>Required value</b> gate:
-    when a value is set, only callers whose token carries that claim/value can see or call this
-    server's tools — everyone else connects but sees none. This is separate from (and layered on
-    top of) the Event handler's own admin-tools gate, and only affects this one standalone
-    server, not the shared embedded endpoint.</p>
+    when a value is set, only callers whose token carries one of those claim values can see or call
+    this server's tools — everyone else connects but sees none. The value is a comma-separated
+    any-of list, and each <code>hal2MCPIn</code> tool can add a narrower list of its own that is
+    checked on top of it. This gate only affects this one standalone server, not the shared
+    embedded endpoint or its read/write gates.</p>
     <p>See the <a href="https://github.com/flic/node-red-contrib-hal2#readme" target="_blank">project README</a>
     for a worked example (<code>examples/jellyfin-mcp.json</code>).</p>
 </script>

--- a/core/mcpserver.js
+++ b/core/mcpserver.js
@@ -1,12 +1,18 @@
 const crypto = require('crypto');
 const { createHttpGuards, hostFilter } = require('../lib/httpGuards');
-const { claimSatisfied } = require('../lib/common');
+const { handleRpc } = require('../lib/mcp-rpc');
 
-function removeRoute(RED, path) {
+// Remove only THIS node's registration for the path. Several standalone servers may share a
+// path when hostname filtering splits them by Host header, so matching on path alone would
+// let a partial deploy of one node silently strip its siblings' routes. Ownership is read off
+// the tagged hostFilter middleware each chain starts with; untagged layers are left alone.
+function removeRoute(RED, path, ownerId) {
     if (!RED.httpNode || !RED.httpNode._router) return;
     RED.httpNode._router.stack = RED.httpNode._router.stack.filter(layer => {
         if (!layer.route) return true;
-        return !(layer.route.path === path && layer.route.methods['post']);
+        if (layer.route.path !== path || !layer.route.methods['post']) return true;
+        return !(layer.route.stack || []).some(l =>
+            l.handle && l.handle._mcpOwner !== undefined && l.handle._mcpOwner === ownerId);
     });
 }
 
@@ -34,11 +40,11 @@ module.exports = function (RED) {
         // Tools appear on the shared /mcp endpoint alongside built-in tools.
 
         if (config.mode === 'embedded') {
-            node.registerMCPTool = (name, description, schema, timeoutSec) =>
-                eventHandler.registerMCPTool(name, description, schema, timeoutSec);
+            node.registerMCPTool = (name, description, schema, timeoutSec, requiredValue, ownerId) =>
+                eventHandler.registerMCPTool(name, description, schema, timeoutSec, requiredValue, ownerId);
 
-            node.unregisterMCPTool = name =>
-                eventHandler.unregisterMCPTool(name);
+            node.unregisterMCPTool = (name, ownerId) =>
+                eventHandler.unregisterMCPTool(name, ownerId);
 
             node.resolveMCPCall = (callId, content) =>
                 eventHandler.resolveMCPCall(callId, content);
@@ -62,14 +68,28 @@ module.exports = function (RED) {
         // ── Standalone mode ───────────────────────────────────────────────────
         // Registers its own POST /mcp/<path> route. Shares auth with EventHandler.
 
-        node.mcpRegisteredTools = {};
-        node.mcpPendingCalls    = {};
+        // Null-prototype: names arrive from remote callers, and a plain {} resolves
+        // "__proto__" or "constructor" through the prototype chain past the unknown-tool check.
+        node.mcpRegisteredTools = Object.create(null);
+        node.mcpPendingCalls    = Object.create(null);
 
-        node.registerMCPTool = function (name, description, schema, timeoutSec) {
-            node.mcpRegisteredTools[name] = { description, schema, timeoutMs: timeoutSec * 1000 };
+        node.registerMCPTool = function (name, description, schema, timeoutSec, requiredValue, ownerId) {
+            const existing = node.mcpRegisteredTools[name];
+            if (existing && existing.ownerId !== ownerId) {
+                node.warn('MCP tool "' + name + '" is registered by more than one hal2MCPIn node on this '
+                    + 'server — each call will run every one of those flows, with unpredictable results. '
+                    + 'Rename the tools so each name is unique.');
+            }
+            node.mcpRegisteredTools[name] = {
+                description, schema, timeoutMs: timeoutSec * 1000,
+                requiredValue: requiredValue || '', ownerId
+            };
         };
 
-        node.unregisterMCPTool = function (name) {
+        node.unregisterMCPTool = function (name, ownerId) {
+            const entry = node.mcpRegisteredTools[name];
+            if (!entry) { return; }
+            if (ownerId !== undefined && entry.ownerId !== undefined && entry.ownerId !== ownerId) { return; }
             delete node.mcpRegisteredTools[name];
         };
 
@@ -94,8 +114,6 @@ module.exports = function (RED) {
         // Default '' (allow all) only when never set. Empty string stays "any authenticated user".
         const requiredValue = (config.requiredValue === undefined ? '' : config.requiredValue).trim();
 
-        const hasAccess = claims => claimSatisfied(claims, requiredClaim, requiredValue);
-
         node.log('hal2MCPServer registering route: POST ' + mcpPath);
 
         // Same hardening as the EventHandler's /mcp route (see lib/httpGuards.js).
@@ -105,88 +123,42 @@ module.exports = function (RED) {
         // shares its hostname split. Empty (feature off, or single-host) → matches on path only.
         const expectedHost = eventHandler.mcpExpectedHost || '';
 
-        RED.httpNode.post(mcpPath, hostFilter(expectedHost), rateLimit('mcp', 300), maxBody(1024 * 1024), async (req, res) => {
+        // The whole decision surface — initialize, tools/list, tools/call, ping, and the
+        // gates over them — lives in lib/mcp-rpc.js, shared with node-red-contrib-mcp-server
+        // and unit-tested there. This handler is glue: authenticate, dispatch, write.
+        const rpcDeps = {
+            serverName, serverVersion: '1.0.0', instructions,
+            requiredClaim, requiredValue,
+            // A standalone server exposes only flow-defined tools; the built-in catalog and
+            // its admin tools belong to the Event handler's embedded endpoint.
+            adminToolsEnabled: false,
+            adminTools: { TOOLS: [], TOOL_NAMES: new Set(), callTool: async () => '' },
+            tools: node.mcpRegisteredTools,
+            // Hands the call to the flow and waits for the matching hal2MCPOut, or times out.
+            callTool: (name, timeoutMs, args, claims) => new Promise((resolve, reject) => {
+                const callId = crypto.randomBytes(16).toString('hex');
+                const timer  = setTimeout(() => {
+                    delete node.mcpPendingCalls[callId];
+                    reject(new Error('timeout'));
+                }, timeoutMs);
+                node.mcpPendingCalls[callId] = { resolve, reject, timer };
+                node.emit('mcp_tool_' + name, { args, _mcpCallId: callId, _mcpClaims: claims });
+            }),
+            status: s => node.status(s)
+        };
+
+        const guard = hostFilter(expectedHost);
+        // Tag the first middleware so removeRoute can tell this node's chain from a sibling's.
+        guard._mcpOwner = node.id;
+
+        RED.httpNode.post(mcpPath, guard, rateLimit('mcp', 300), maxBody(1024 * 1024), async (req, res) => {
             const claims = await eventHandler.requireBearer(req, res);
             if (!claims) return;
 
-            const allowed = hasAccess(claims);
-
-            const body   = req.body || {};
-            const id     = body.id     !== undefined ? body.id : null;
-            const method = body.method || null;
-            const params = body.params || {};
-
-            const respond = result => res.status(200).json({ jsonrpc: '2.0', id, result });
-            const rpcErr  = (c, m)  => res.status(200).json({ jsonrpc: '2.0', id, error: { code: c, message: m } });
-            const toolOk  = text    => respond({ content: [{ type: 'text', text }] });
-
-            if (method === 'initialize') {
-                node.status({ fill: 'green', shape: 'dot', text: 'connected' });
-                res.set('Cache-Control', 'no-store');
-                // Don't leak tool names to callers who lack the required claim.
-                const toolNames = allowed ? Object.keys(node.mcpRegisteredTools).join(', ') : '';
-                return respond({
-                    protocolVersion : '2024-11-05',
-                    capabilities    : { tools: {} },
-                    serverInfo      : { name: serverName, version: '1.0.0' },
-                    instructions    : (instructions ? instructions + ' ' : '') +
-                                      (toolNames ? 'Available tools: ' + toolNames + '.' : '')
-                });
-            }
-
-            if (method === 'notifications/initialized') {
-                return res.status(204).send('');
-            }
-
-            if (method === 'tools/list') {
-                if (!allowed) return respond({ tools: [] });
-                const tools = [];
-                for (const [name, t] of Object.entries(node.mcpRegisteredTools)) {
-                    const s = t.schema;
-                    const inputSchema = (s && s.type === 'object') ? s : { type: 'object', properties: s || {} };
-                    tools.push({ name, description: t.description, inputSchema });
-                }
-                return respond({ tools });
-            }
-
-            if (method === 'tools/call') {
-                // Return the denial as a tool result (isError) rather than a JSON-RPC protocol
-                // error — clients surface a result's text to the model, but collapse a protocol
-                // error into a generic "tool execution failed" with no reason.
-                if (!allowed) return respond({
-                    content: [{ type: 'text', text: 'Access denied: your account lacks the required permission to use this server.' }],
-                    isError: true
-                });
-                const toolName = params.name;
-                const args     = params.arguments || {};
-                node.status({ fill: 'blue', shape: 'dot', text: toolName });
-
-                if (node.mcpRegisteredTools[toolName]) {
-                    try {
-                        const callId    = crypto.randomBytes(16).toString('hex');
-                        const timeoutMs = node.mcpRegisteredTools[toolName].timeoutMs || 30000;
-                        const result    = await new Promise((resolve, reject) => {
-                            const timer = setTimeout(() => {
-                                delete node.mcpPendingCalls[callId];
-                                reject(new Error('timeout'));
-                            }, timeoutMs);
-                            node.mcpPendingCalls[callId] = { resolve, reject, timer };
-                            node.emit('mcp_tool_' + toolName, { args, _mcpCallId: callId, _mcpClaims: claims });
-                        });
-                        node.status({ fill: 'green', shape: 'dot', text: 'ready' });
-                        return Array.isArray(result)
-                            ? respond({ content: result })
-                            : toolOk(result);
-                    } catch (e) {
-                        node.status({ fill: 'red', shape: 'dot', text: 'timeout' });
-                        return toolOk(JSON.stringify({ error: e.message === 'timeout' ? 'Tool timed out: ' + toolName : e.message }));
-                    }
-                }
-
-                return rpcErr(-32601, 'Unknown tool: ' + toolName);
-            }
-
-            return rpcErr(-32601, 'Unknown method: ' + (method || 'null'));
+            const out = await handleRpc(req.body, claims, rpcDeps);
+            if (out.headers) res.set(out.headers);
+            res.status(out.status);
+            return out.body !== undefined ? res.json(out.body) : res.send('');
         });
 
         node.status({ fill: 'green', shape: 'dot', text: mcpPath });
@@ -197,7 +169,7 @@ module.exports = function (RED) {
                 pending.reject(new Error('MCP server closing'));
             }
             node.mcpPendingCalls = {};
-            removeRoute(RED, mcpPath);
+            removeRoute(RED, mcpPath, node.id);
         });
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,8 @@ On failure:
 
 Most tools return a JSON object in `result`. A few admin tools return plain text.
 
+Each tool below is tagged 👁 **read**, ✏️ **write** or 🔒 **admin**. Those classes are what the MCP server's [access gates](../README.md#access-control) act on, so a token can be allowed to observe the house without being allowed to change it. They are informational here: the hal2Api node is a local flow node and gates only its admin tools, via its own checkbox.
+
 ## Tools
 
 - [`get_all_states`](#getallstates)
@@ -47,7 +49,7 @@ Most tools return a JSON object in `result`. A few admin tools return plain text
 - [`get_flow`](#getflow)
 - [`deploy_flow`](#deployflow)
 
-### `get_all_states`
+### `get_all_states` 👁 (read)
 
 Returns the current state of all devices/things connected to this event handler. The response includes a location field (e.g. "Home" or "Cabin") identifying which property this server controls. Use fields="summary" (default) for a lightweight list with thing_id, thing_name, type_name and alive — ideal for orientation and ID lookup. Use fields="items" for a compact per-device item index (thing_id, thing_name, type_name, items:[{item_id, item_name, ha_type, history}]) — cheap way to find an item_id without the full dump. Use fields="full" to include all items with item_id, item_name, ha_type and current value. Each item and each device always includes a last_change field (ISO 8601 UTC timestamp, null if the value has not changed since startup) — when the value last actually changed. Use this to answer "when did X happen?" without an extra get_history call. Each device has an alive field (true/false) — if false the device is offline. Only items with a ha_type are included in full mode. Responses include free-text notes and tags on both Thing and Item level when configured — use them to disambiguate what a device actually measures or controls (e.g. "Pool Sensor" notes: "pool water temperature"). Each device also includes a categories field listing which control categories it falls into (climate, spa, light, fan, cover, scene), derived from its items — use this to identify what kind of device it is at a glance. ha_type accepts both literal item types (e.g. "light", "temperature") and category aliases that expand to their underlying types — e.g. "climate" matches devices with target temperature / ac mode / fan mode / swing mode. Supported aliases: climate, spa, light, fan, cover, scene. Use tag to limit results to devices/items tagged with a specific keyword. Supports optional pagination via offset and limit. The response includes total.
 
@@ -67,7 +69,7 @@ Returns the current state of all devices/things connected to this event handler.
 { "tool": "get_all_states", "args": { "fields": "summary", "ha_type": "…" } }
 ```
 
-### `get_state`
+### `get_state` 👁 (read)
 
 Returns the complete state for a specific device. Use this to fetch full details for one device by its thing_id. Provide thing_id for an exact lookup or thing_name for a partial, case-insensitive match. Response includes notes and tags on both Thing and Item level when configured. Each item and the device itself include last_change (ISO 8601 UTC) — when the value last actually changed. Optionally provide item_id to return only a single item value — the item is a measurement/control within the device, not the device name. If item_id is wrong, the error response lists available_items for that thing so you can pick the right one.
 
@@ -85,7 +87,7 @@ Returns the complete state for a specific device. Use this to fetch full details
 { "tool": "get_state", "args": { "thing_id": "…", "thing_name": "…" } }
 ```
 
-### `get_history`
+### `get_history` 👁 (read)
 
 Returns logged historical values for a specific device item — temperature and other sensor readings over time, time series for a graph/chart, trends, statistics, activity. Use this whenever the user asks about history, statistics, trends, activity over time, how often something happened, when it last changed, or similar time-based questions. Items that support history are marked with history:true in get_all_states. NOTE: a thing is the device, an item is a measurement/control WITHIN it — they are separate namespaces with separate names (e.g. the device "Sjövatten Sensor" contains an item named "Temperatur"), so a thing name will not match an item name. If you know the device but not the exact item, pass ha_type (e.g. ha_type="temperature") and the server resolves the item for you. If a device has several items of the same ha_type (e.g. an indoor and an outdoor temperature), combine ha_type with tag (e.g. tag="ute") to pick the right one — items and their tags are listed in available_items when the match is ambiguous. If item resolution fails, the error response includes available_items (item_id, item_name, ha_type, history) for that thing — pick from it, no full get_all_states dump needed. Returns an array of objects with timestamp (ISO 8601 UTC, e.g. "2026-05-28T12:03:11.000Z") and state fields, sorted oldest-first. Time window — use one of these forms: (1) hours: number of hours back from now (default: 24); (2) from + to: explicit ISO datetime strings or epoch ms, e.g. from="2026-05-01T00:00:00" to="2026-05-02T00:00:00"; (3) from only: from that point until now; (4) at: returns the single most recent record at or before that moment — useful for "what was the value at time X?". Use offset and limit to page through large result sets (default limit: 500). The response includes total so you know how many calls are needed. DOWNSAMPLING: for long ranges of a NUMERIC item (e.g. a week of temperature for a graph), set bucket to "minute", "hour" or "day" (or bucket_seconds for a custom interval). The server then aggregates per time bucket and returns a compact "buckets" array — each entry { start, count, avg, min, max } (avg/min/max rounded to numeric_precision; bucket start is local time, e.g. a "day" is local midnight) — instead of all raw samples. Prefer this over fetching raw data and averaging yourself. Buckets with no data are omitted. Aggregation is numeric-only; for non-numeric items (on/off, mode) use bucket="raw" (the default).
 
@@ -115,7 +117,7 @@ Returns logged historical values for a specific device item — temperature and 
 { "tool": "get_history", "args": { "thing_id": "…", "thing_name": "…" } }
 ```
 
-### `control_device`
+### `control_device` ✏️ (write)
 
 Send a command to a specific device item. Use thing_id and item_id from get_all_states. The item is the control WITHIN the device (e.g. an "On" item), not the device name. If the item_id is wrong or read-only, the error response lists available_items (item_id, item_name, ha_type, read_only) for that thing — pick a controllable one from it.
 
@@ -133,7 +135,7 @@ Send a command to a specific device item. Use thing_id and item_id from get_all_
 { "tool": "control_device", "args": { "thing_id": "…", "item_id": "…", "value": "…" } }
 ```
 
-### `control_fan`
+### `control_fan` ✏️ (write)
 
 Control a ceiling fan. Identify by thing_id or thing_name (partial, case-insensitive). Speed 0 = off, 1 = low, 2 = medium, 3 = high. Current speed is available via get_all_states.
 
@@ -153,7 +155,7 @@ Control a ceiling fan. Identify by thing_id or thing_name (partial, case-insensi
 { "tool": "control_fan", "args": { "thing_id": "…", "thing_name": "…" } }
 ```
 
-### `get_scenes`
+### `get_scenes` 👁 (read)
 
 Returns all scenes with their current status (active/inactive) and last_change (ISO 8601 UTC) — when the scene was last activated or deactivated. Use this to answer "is scene X active?", "which scenes are active right now?" or "when was scene Y last activated?".
 
@@ -171,7 +173,7 @@ Returns all scenes with their current status (active/inactive) and last_change (
 { "tool": "get_scenes", "args": { "name": "…" } }
 ```
 
-### `activate_scene`
+### `activate_scene` ✏️ (write)
 
 Activate or deactivate a scene by name or ID. Use get_scenes to find available scenes.
 
@@ -191,7 +193,7 @@ Activate or deactivate a scene by name or ID. Use get_scenes to find available s
 { "tool": "activate_scene", "args": { "thing_id": "…", "thing_name": "…" } }
 ```
 
-### `control_cover`
+### `control_cover` ✏️ (write)
 
 Control curtains, blinds or shutters. Identify by thing_id or thing_name (partial, case-insensitive). Use position to set an exact opening level, or open/close as a shortcut. Current position is available via get_all_states.
 
@@ -212,7 +214,7 @@ Control curtains, blinds or shutters. Identify by thing_id or thing_name (partia
 { "tool": "control_cover", "args": { "thing_id": "…", "thing_name": "…" } }
 ```
 
-### `control_spa`
+### `control_spa` ✏️ (write)
 
 Control a spa or hot tub. Identify by thing_id or thing_name (partial, case-insensitive). Current status (water temperature, heater state etc.) is available via get_all_states. All control parameters are optional — only provided ones are sent.
 
@@ -235,7 +237,7 @@ Control a spa or hot tub. Identify by thing_id or thing_name (partial, case-inse
 { "tool": "control_spa", "args": { "thing_id": "…", "thing_name": "…" } }
 ```
 
-### `control_climate`
+### `control_climate` ✏️ (write)
 
 Control a heat pump or AC unit. Identify by thing_id or thing_name (partial, case-insensitive). Current status is available via get_all_states. All parameters are optional — only provided ones are sent.
 
@@ -258,7 +260,7 @@ Control a heat pump or AC unit. Identify by thing_id or thing_name (partial, cas
 { "tool": "control_climate", "args": { "thing_id": "…", "thing_name": "…" } }
 ```
 
-### `get_presence`
+### `get_presence` 👁 (read)
 
 Returns presence information for all people/persons tracked in the system. Shows who is home, who is away, and which room each person is in. Use this to answer questions like "is anyone home?", "where is Alice?", "who is home right now?", "when did Bob come home?", "how long has Alice been away?". Each person includes home_since/away_since (ISO timestamp of last change) and home_for_minutes/away_for_minutes (duration in current state). When home, also includes room, room_since and in_room_for_minutes. thing_id and item ids are included so follow-up tools (get_history, set_light, etc.) can be called without an extra lookup. A summary block provides aggregated counts and name lists.
 
@@ -272,7 +274,7 @@ _No parameters._
 { "tool": "get_presence", "args": {  } }
 ```
 
-### `get_alerts`
+### `get_alerts` 👁 (read)
 
 Returns water leak sensor status, devices with low battery, and offline devices in one call. Use this to answer "is there a water leak?", "which sensors have low battery?", "are any devices offline?", "what needs attention?" or similar questions about sensor alerts. Each entry always includes last_change (ISO 8601 UTC, null if unknown) — for water sensors this is when the wet/dry state changed, for low-battery items when the level last changed, and for offline devices when they went offline.
 
@@ -288,7 +290,7 @@ Returns water leak sensor status, devices with low battery, and offline devices 
 { "tool": "get_alerts", "args": { "battery_threshold": 0 } }
 ```
 
-### `set_light`
+### `set_light` ✏️ (write)
 
 Control a specific light or lamp. Identify the device by thing_id OR thing_name. thing_name supports partial, case-insensitive match against the thing name OR against item labels (the label field in get_all_states items). Labels are friendly names assigned per-device, e.g. a double switch named "Kitchen Double Switch" may have items labelled "Kitchen Ceiling Light" and "Kitchen Counter Light" — searching "counter" will target only that relay. You can turn it on/off and/or set brightness/color_temp/color in one call.
 
@@ -311,7 +313,7 @@ Control a specific light or lamp. Identify the device by thing_id OR thing_name.
 { "tool": "set_light", "args": { "thing_id": "…", "thing_name": "…" } }
 ```
 
-### `analyze_patterns`
+### `analyze_patterns` 👁 (read)
 
 Analyzes the history database to detect recurring behavioral patterns — e.g. "Living Room Light turns ON around 07:30, 85% consistent". Detects state transitions (actual changes), groups them into time-of-day windows, and returns suggestions sorted by consistency score. Also reports stale items (no activity in 30+ days). By default, state changes caused by hal2 itself are excluded so existing automations are not re-suggested as patterns. Requires history to be enabled on the event handler. Use when the user asks about automating routines or finding patterns in device usage.
 

--- a/lib/claim-gate.js
+++ b/lib/claim-gate.js
@@ -1,6 +1,7 @@
 'use strict';
 // Claim-based access gates for the mcp-server config node. One claim name is configured on
-// the server (default `groups`); every other authorization field is a comma-separated list of
+// the server (default `groups`, or a dotted path such as `realm_access.roles` for providers
+// that nest); every other authorization field is a comma-separated list of
 // values matched any-of against that claim. Gates compose with AND: reaching a tool means
 // clearing the server's list and that tool's own list. An empty list is no constraint at all.
 //
@@ -16,14 +17,44 @@ function parseList(list) {
     return list.split(',').map(s => s.trim()).filter(Boolean);
 }
 
+// Read the configured claim out of a token payload. A literal key always wins, so any claim
+// name that resolves today keeps resolving to exactly the same value; only a dotted name with
+// no matching literal key is walked as a path. That covers providers that nest their roles —
+// Keycloak's `realm_access.roles`, Auth0's namespaced objects — without hard-coding any.
+//
+// Note what this can change: a dotted name previously matched nothing and therefore denied
+// everyone. Such a gate now starts resolving, which is the point of the change but does mean
+// a config that was failing closed by accident becomes permissive as its author intended.
+//
+// Traversal stops at anything that is not a plain object, so `a.b` against `{ a: ['x'] }`
+// yields undefined rather than reaching into array indices, and `hasOwnProperty` at each step
+// keeps a name like `constructor.name` from walking the prototype chain.
+function readClaim(claims, claimName) {
+    if (!claims || typeof claimName !== 'string' || !claimName) return undefined;
+    if (Object.prototype.hasOwnProperty.call(claims, claimName)) return claims[claimName];
+    if (claimName.indexOf('.') === -1) return undefined;
+    let node = claims;
+    for (const part of claimName.split('.')) {
+        if (!node || typeof node !== 'object' || Array.isArray(node)) return undefined;
+        if (!Object.prototype.hasOwnProperty.call(node, part)) return undefined;
+        node = node[part];
+    }
+    return node;
+}
+
 // Does `list` actively grant access? An empty list grants nothing — treating empty as "allow"
 // is a policy decision belonging to the caller (see claimAllows), not to the matching itself.
+//
+// Only strings and arrays of them match. Strict equality already excluded numbers and booleans;
+// the explicit check states the rule and keeps an object-valued claim — which a dotted path can
+// now easily produce, e.g. the `realm_access` container itself — from being compared at all.
 function grants(claims, claimName, list) {
     const wanted = parseList(list);
     if (!wanted.length) return false;
     if (!claims) return false;
-    const v = claims[claimName];
+    const v = readClaim(claims, claimName);
     if (Array.isArray(v)) return wanted.some(w => v.includes(w));
+    if (typeof v !== 'string') return false;
     return wanted.some(w => v === w);
 }
 
@@ -57,4 +88,4 @@ function visibleTools(registeredTools, gate) {
     return tools;
 }
 
-module.exports = { grants, claimAllows, createToolGate, visibleTools };
+module.exports = { readClaim, grants, claimAllows, createToolGate, visibleTools };

--- a/lib/claim-gate.js
+++ b/lib/claim-gate.js
@@ -1,0 +1,60 @@
+'use strict';
+// Claim-based access gates for the mcp-server config node. One claim name is configured on
+// the server (default `groups`); every other authorization field is a comma-separated list of
+// values matched any-of against that claim. Gates compose with AND: reaching a tool means
+// clearing the server's list and that tool's own list. An empty list is no constraint at all.
+//
+// Pure and dependency-free, so the whole authorization model is unit-testable in isolation —
+// the node's request handler is thin glue that builds a gate from the verified claims and asks
+// it yes/no questions.
+
+// Split a configured value into its individual values. Comma only, deliberately: group names
+// may legitimately contain spaces, and the single-value fields this generalizes always matched
+// the raw (trimmed) string.
+function parseList(list) {
+    if (typeof list !== 'string') return [];
+    return list.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+// Does `list` actively grant access? An empty list grants nothing — treating empty as "allow"
+// is a policy decision belonging to the caller (see claimAllows), not to the matching itself.
+function grants(claims, claimName, list) {
+    const wanted = parseList(list);
+    if (!wanted.length) return false;
+    if (!claims) return false;
+    const v = claims[claimName];
+    if (Array.isArray(v)) return wanted.some(w => v.includes(w));
+    return wanted.some(w => v === w);
+}
+
+// A single gate field: an empty list imposes no constraint, otherwise the claim must match it.
+function claimAllows(claims, claimName, list) {
+    if (!parseList(list).length) return true;
+    return grants(claims, claimName, list);
+}
+
+// Bundles the per-request decision: the server-wide field, plus `allows()` for any additional
+// per-tool field. Every tool — dynamic or admin — goes through `allows`, so the server gate can
+// never be bypassed by a tool's own list.
+function createToolGate({ claims, claimName, serverValue }) {
+    const serverGranted = claimAllows(claims, claimName, serverValue);
+    return {
+        serverGranted,
+        allows: list => serverGranted && claimAllows(claims, claimName, list)
+    };
+}
+
+// The `tools/list` payload for one caller: registered tools the gate permits, with their schema
+// normalized to a JSON-Schema object (a bare properties map is accepted as a convenience).
+function visibleTools(registeredTools, gate) {
+    const tools = [];
+    for (const [name, t] of Object.entries(registeredTools || {})) {
+        if (!gate.allows(t.requiredValue)) continue;
+        const s = t.schema;
+        const inputSchema = (s && s.type === 'object') ? s : { type: 'object', properties: s || {} };
+        tools.push({ name, description: t.description, inputSchema });
+    }
+    return tools;
+}
+
+module.exports = { grants, claimAllows, createToolGate, visibleTools };

--- a/lib/common.js
+++ b/lib/common.js
@@ -70,21 +70,8 @@ function thingIdFromMsg(RED,node,type,msg) {
     }
 }
 
-// Claim/value gate shared by the MCP admin-tools gate and the standalone MCP server gate.
-// An empty value leaves the gate open (any authenticated caller passes); otherwise the caller's
-// validated token must carry the claim with that value — an array claim must include it, a
-// scalar claim must equal it. A missing claims object never passes a non-empty gate.
-function claimSatisfied(claims, claim, value) {
-    if (!value) return true;
-    if (!claims) return false;
-    const v = claims[claim];
-    if (Array.isArray(v)) return v.includes(value);
-    return v === value;
-}
-
 module.exports = {
     queueSend: queueSend,
     createThrottledQueue: createThrottledQueue,
-    thingIdFromMsg: thingIdFromMsg,
-    claimSatisfied: claimSatisfied
+    thingIdFromMsg: thingIdFromMsg
 }

--- a/lib/mcp-rpc.js
+++ b/lib/mcp-rpc.js
@@ -1,0 +1,147 @@
+'use strict';
+// The MCP JSON-RPC dispatcher: everything that decides what a caller may see and do —
+// initialize, tools/list, tools/call, ping — separated from Express and Node-RED so the
+// whole decision surface is unit-testable. The mcp-server node's route handler is thin
+// glue: authenticate, call handleRpc, write the described response.
+//
+// Side effects stay injected via deps: `callTool` performs the actual flow dispatch
+// (pending-call promise, event emit, timeout) and `status` updates the node's editor
+// badge. handleRpc itself never touches the network or the runtime.
+
+const { createToolGate, visibleTools } = require('./claim-gate');
+
+// handleRpc(body, claims, deps) → { status, headers?, body? }
+//   body    — the parsed JSON-RPC request (may be null/undefined)
+//   claims  — the caller's verified JWT claims (from requireBearer)
+//   deps    — {
+//     serverName, serverVersion, instructions,
+//     requiredClaim, requiredValue,            // the server-wide claim gate
+//     adminToolsEnabled, adminRequiredValue,   // admin gate value list
+//     adminTools,                              // { TOOLS, TOOL_NAMES, callTool }
+//     tools,                                   // live registry: name → { description, schema, timeoutMs, requiredValue }
+//     callTool(name, timeoutMs, args, claims), // dispatch one dynamic tool call, resolves content
+//     status(statusObj)                        // optional node.status passthrough
+//   }
+// An absent body field is missing from the result: body:undefined means "no JSON body"
+// (used for the 204 notification ack).
+async function handleRpc(body, claims, deps) {
+    const {
+        serverName, serverVersion, instructions = '',
+        requiredClaim, requiredValue,
+        adminToolsEnabled = false, adminRequiredValue = '',
+        adminTools, tools, callTool,
+        status = () => {}
+    } = deps;
+
+    body = body || {};
+    const id     = body.id !== undefined ? body.id : null;
+    const method = body.method || null;
+    const params = body.params || {};
+
+    const respond = (result, headers) => ({ status: 200, headers, body: { jsonrpc: '2.0', id, result } });
+    const rpcErr  = (code, message)   => ({ status: 200, body: { jsonrpc: '2.0', id, error: { code, message } } });
+    const toolOk  = text => respond({ content: [{ type: 'text', text }] });
+    // Denials surfaced as a tool result (isError) rather than a JSON-RPC protocol error —
+    // clients show a result's text to the model, but collapse a protocol error into a
+    // generic "tool execution failed" with no reason.
+    const denied  = text => respond({ content: [{ type: 'text', text }], isError: true });
+
+    // One gate per request: `serverGranted` is the whole-server list, `allows(list)` adds a
+    // tool's own list on top of it. Every tool — dynamic or admin — goes through `allows`.
+    const gate    = createToolGate({ claims, claimName: requiredClaim, serverValue: requiredValue });
+    const allowed = gate.serverGranted;
+    const adminAllowed = adminToolsEnabled && gate.allows(adminRequiredValue);
+
+    // The registry may be a plain object built by older code — never resolve caller-supplied
+    // names ("__proto__", "constructor", …) through its prototype chain.
+    const toolEntry = name =>
+        Object.prototype.hasOwnProperty.call(tools, name) ? tools[name] : undefined;
+
+    if (method === 'initialize') {
+        status({ fill: 'green', shape: 'dot', text: 'connected' });
+        // Don't leak tool names to callers who lack the required claim — neither the
+        // server's own list nor any individual tool's. Same filter as tools/list.
+        const toolNames = allowed ? [
+            ...visibleTools(tools, gate).map(t => t.name),
+            ...(adminAllowed ? [...adminTools.TOOL_NAMES] : [])
+        ] : [];
+        return respond({
+            protocolVersion : '2024-11-05',
+            capabilities    : { tools: {} },
+            serverInfo      : { name: serverName, version: serverVersion },
+            instructions    : (instructions ? instructions + ' ' : '') +
+                              (toolNames.length ? 'Available tools: ' + toolNames.join(', ') + '.' : '')
+        }, { 'Cache-Control': 'no-store' });
+    }
+
+    if (method === 'notifications/initialized') {
+        return { status: 204 };
+    }
+
+    // MCP-level keepalive; some clients probe with it and treat an error as a dead server.
+    if (method === 'ping') {
+        return respond({});
+    }
+
+    if (method === 'tools/list') {
+        if (!allowed) return respond({ tools: [] });
+        const list = visibleTools(tools, gate);
+        if (adminAllowed) list.push(...adminTools.TOOLS);
+        return respond({ tools: list });
+    }
+
+    if (method === 'tools/call') {
+        if (!allowed) {
+            return denied('Access denied: your account lacks the required permission to use this server.');
+        }
+        const toolName = params.name;
+        const args     = params.arguments || {};
+        status({ fill: 'blue', shape: 'dot', text: toolName });
+
+        const entry = toolEntry(toolName);
+        if (entry) {
+            // Per-tool gate, checked on every call rather than only at listing time.
+            if (!gate.allows(entry.requiredValue)) {
+                status({ fill: 'red', shape: 'ring', text: 'forbidden' });
+                return denied('Access denied: the "' + toolName + '" tool requires a permission '
+                    + 'your token does not have. This is a permission restriction, not a tool error.');
+            }
+            try {
+                const result = await callTool(toolName, entry.timeoutMs || 30000, args, claims);
+                status({ fill: 'green', shape: 'dot', text: 'ready' });
+                return Array.isArray(result)
+                    ? respond({ content: result })
+                    : toolOk(result);
+            } catch (e) {
+                status({ fill: 'red', shape: 'dot', text: 'timeout' });
+                return toolOk(JSON.stringify({ error: e.message === 'timeout' ? 'Tool timed out: ' + toolName : e.message }));
+            }
+        }
+
+        if (adminTools.TOOL_NAMES.has(toolName)) {
+            if (!adminToolsEnabled) return rpcErr(-32601, 'Unknown tool: ' + toolName);
+            // Admin tools require a verified admin claim on every call — the
+            // adminToolsEnabled flag alone is never sufficient to reach them.
+            if (!gate.allows(adminRequiredValue)) {
+                status({ fill: 'red', shape: 'ring', text: 'forbidden' });
+                return denied('Access denied: the "' + toolName + '" tool requires admin privileges, '
+                    + 'which your token does not have. This is a permission restriction, not a tool error.');
+            }
+            try {
+                const result = await adminTools.callTool(toolName, args);
+                status({ fill: 'green', shape: 'dot', text: 'ready' });
+                return toolOk(result);
+            } catch (e) {
+                if (e.rpcCode) return rpcErr(e.rpcCode, e.message);
+                status({ fill: 'red', shape: 'ring', text: 'admin error' });
+                return toolOk('Admin call error: ' + e.message);
+            }
+        }
+
+        return rpcErr(-32601, 'Unknown tool: ' + toolName);
+    }
+
+    return rpcErr(-32601, 'Unknown method: ' + (method || 'null'));
+}
+
+module.exports = { handleRpc };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.4.2",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.4.2",
+      "version": "2.5.1",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/scripts/gen-api-docs.js
+++ b/scripts/gen-api-docs.js
@@ -5,7 +5,7 @@
 const fs   = require('fs');
 const path = require('path');
 const {
-    MCP_TOOLS, MCP_TOOLS_ADMIN, TOOL_HARDWARE_REQUIREMENTS
+    MCP_TOOLS, MCP_TOOLS_ADMIN, TOOL_HARDWARE_REQUIREMENTS, toolClass
 } = require('../core/mcp-tools');
 
 function sampleValue(prop) {
@@ -47,7 +47,9 @@ function exampleRequest(tool) {
 }
 
 function section(tool, isAdmin) {
-    let md = `### \`${tool.name}\`${isAdmin ? ' 🔒 (admin)' : ''}\n\n`;
+    const cls = isAdmin ? 'admin' : toolClass(tool.name);
+    const badge = { read: '👁 (read)', write: '✏️ (write)', admin: '🔒 (admin)' }[cls];
+    let md = `### \`${tool.name}\` ${badge}\n\n`;
     md += tool.description.trim() + '\n\n';
     const hw = TOOL_HARDWARE_REQUIREMENTS[tool.name];
     if (hw) md += `> **Requires hardware:** at least one item of type ${hw.map(t => '`' + t + '`').join(', ')} at this location.\n\n`;
@@ -75,6 +77,10 @@ function build() {
     md += '```json\n{ "ok": true, "result": /* tool output */ }\n```\n\n';
     md += 'On failure:\n\n```json\n{ "ok": false, "error": { "code": -32601, "message": "…" } }\n```\n\n';
     md += 'Most tools return a JSON object in `result`. A few admin tools return plain text.\n\n';
+    md += 'Each tool below is tagged 👁 **read**, ✏️ **write** or 🔒 **admin**. Those classes are what the ';
+    md += 'MCP server\'s [access gates](../README.md#access-control) act on, so a token can be allowed to ';
+    md += 'observe the house without being allowed to change it. They are informational here: the hal2Api ';
+    md += 'node is a local flow node and gates only its admin tools, via its own checkbox.\n\n';
     md += '## Tools\n\n' + toc + '\n\n';
     for (const t of MCP_TOOLS)       md += section(t, false);
     md += '## Admin tools\n\n';

--- a/test/claim-gate.test.js
+++ b/test/claim-gate.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('node:assert');
-const { grants, claimAllows, createToolGate, visibleTools } = require('../lib/claim-gate');
+const { readClaim, grants, claimAllows, createToolGate, visibleTools } = require('../lib/claim-gate');
 
 describe('lib/claim-gate grants', function () {
     it('grants nothing for an empty or absent list', function () {
@@ -42,9 +42,64 @@ describe('lib/claim-gate grants', function () {
         assert.strictEqual(grants({ groups: [''] }, 'groups', 'a,,b'), false);
     });
 
+    it('matches a nested claim addressed by a dotted path', function () {
+        const keycloak = { realm_access: { roles: ['ops'] } };
+        assert.strictEqual(grants(keycloak, 'realm_access.roles', 'ops'), true);
+        assert.strictEqual(grants(keycloak, 'realm_access.roles', 'admin'), false);
+        assert.strictEqual(grants({ nested: { role: 'ops' } }, 'nested.role', 'ops'), true);
+        // The container object itself is not a match for anything.
+        assert.strictEqual(grants(keycloak, 'realm_access', 'ops'), false);
+    });
+
+    it('grants nothing for a claim that is neither string nor array', function () {
+        assert.strictEqual(grants({ n: 5 }, 'n', '5'), false);
+        assert.strictEqual(grants({ b: true }, 'b', 'true'), false);
+        assert.strictEqual(grants({ o: { a: 1 } }, 'o', '[object Object]'), false);
+    });
+
     it('keeps values containing spaces intact — only commas separate', function () {
         assert.strictEqual(grants({ groups: ['power users'] }, 'groups', 'power users'), true);
         assert.strictEqual(grants({ groups: ['power'] }, 'groups', 'power users'), false);
+    });
+});
+
+describe('lib/claim-gate readClaim', function () {
+    const KEYCLOAK = { sub: 'x', realm_access: { roles: ['ops', 'default-roles'] } };
+
+    it('reads a top-level claim', function () {
+        assert.deepStrictEqual(readClaim({ groups: ['a'] }, 'groups'), ['a']);
+        assert.strictEqual(readClaim({ role: 'admin' }, 'role'), 'admin');
+    });
+
+    it('walks a dotted path when there is no literal key', function () {
+        assert.deepStrictEqual(readClaim(KEYCLOAK, 'realm_access.roles'), ['ops', 'default-roles']);
+        assert.strictEqual(readClaim({ a: { b: { c: 'deep' } } }, 'a.b.c'), 'deep');
+    });
+
+    it('prefers a literal key over the path reading of the same name', function () {
+        // A provider that really does emit a key with a dot in it must keep working, and an
+        // existing gate configured against one must not start resolving somewhere else.
+        const both = { 'realm_access.roles': ['literal'], realm_access: { roles: ['nested'] } };
+        assert.deepStrictEqual(readClaim(both, 'realm_access.roles'), ['literal']);
+    });
+
+    it('returns undefined for a path that goes nowhere', function () {
+        assert.strictEqual(readClaim(KEYCLOAK, 'realm_access.missing'), undefined);
+        assert.strictEqual(readClaim(KEYCLOAK, 'missing.roles'), undefined);
+        assert.strictEqual(readClaim({ a: ['x'] }, 'a.b'), undefined);       // no array indexing
+        assert.strictEqual(readClaim({ a: 'str' }, 'a.length'), undefined);  // no string props
+    });
+
+    it('does not walk the prototype chain', function () {
+        assert.strictEqual(readClaim({}, 'constructor.name'), undefined);
+        assert.strictEqual(readClaim({ a: {} }, 'a.__proto__'), undefined);
+        assert.strictEqual(readClaim({}, 'toString'), undefined);
+    });
+
+    it('handles absent claims and empty names', function () {
+        assert.strictEqual(readClaim(null, 'groups'), undefined);
+        assert.strictEqual(readClaim({ groups: [] }, ''), undefined);
+        assert.strictEqual(readClaim({ groups: [] }, null), undefined);
     });
 });
 

--- a/test/claim-gate.test.js
+++ b/test/claim-gate.test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const assert = require('node:assert');
+const { grants, claimAllows, createToolGate, visibleTools } = require('../lib/claim-gate');
+
+describe('lib/claim-gate grants', function () {
+    it('grants nothing for an empty or absent list', function () {
+        assert.strictEqual(grants({ groups: ['admin'] }, 'groups', ''), false);
+        assert.strictEqual(grants({ groups: ['admin'] }, 'groups', undefined), false);
+        assert.strictEqual(grants({ groups: ['admin'] }, 'groups', '  ,  '), false);
+    });
+
+    it('denies when claims are missing entirely', function () {
+        assert.strictEqual(grants(null, 'groups', 'admin'), false);
+        assert.strictEqual(grants(undefined, 'groups', 'admin'), false);
+    });
+
+    it('matches a scalar claim value', function () {
+        assert.strictEqual(grants({ role: 'admin' }, 'role', 'admin'), true);
+        assert.strictEqual(grants({ role: 'user' }, 'role', 'admin'), false);
+    });
+
+    it('matches an array claim value', function () {
+        assert.strictEqual(grants({ groups: ['user', 'admin'] }, 'groups', 'admin'), true);
+        assert.strictEqual(grants({ groups: ['user'] }, 'groups', 'admin'), false);
+    });
+
+    it('denies when the claim is missing from an otherwise valid claims object', function () {
+        assert.strictEqual(grants({ sub: 'x' }, 'groups', 'admin'), false);
+    });
+
+    it('treats a comma-separated list as any-of', function () {
+        assert.strictEqual(grants({ groups: ['media'] }, 'groups', 'media,ops'), true);
+        assert.strictEqual(grants({ groups: ['ops'] }, 'groups', 'media,ops'), true);
+        assert.strictEqual(grants({ groups: ['guest'] }, 'groups', 'media,ops'), false);
+        assert.strictEqual(grants({ role: 'ops' }, 'role', 'media,ops'), true);
+    });
+
+    it('trims whitespace around list items and ignores empty ones', function () {
+        assert.strictEqual(grants({ groups: ['ops'] }, 'groups', ' media , ops '), true);
+        assert.strictEqual(grants({ groups: ['ops'] }, 'groups', 'media,,ops'), true);
+        assert.strictEqual(grants({ groups: [''] }, 'groups', 'a,,b'), false);
+    });
+
+    it('keeps values containing spaces intact — only commas separate', function () {
+        assert.strictEqual(grants({ groups: ['power users'] }, 'groups', 'power users'), true);
+        assert.strictEqual(grants({ groups: ['power'] }, 'groups', 'power users'), false);
+    });
+});
+
+describe('lib/claim-gate claimAllows', function () {
+    it('allows any caller when the list is empty', function () {
+        assert.strictEqual(claimAllows({ sub: 'x' }, 'groups', ''), true);
+        assert.strictEqual(claimAllows(null, 'groups', ''), true);
+        assert.strictEqual(claimAllows({ sub: 'x' }, 'groups', ' , '), true);
+    });
+
+    it('otherwise defers to grants', function () {
+        assert.strictEqual(claimAllows({ groups: ['admin'] }, 'groups', 'admin'), true);
+        assert.strictEqual(claimAllows({ groups: ['user'] }, 'groups', 'admin'), false);
+        assert.strictEqual(claimAllows(null, 'groups', 'admin'), false);
+    });
+});
+
+describe('lib/claim-gate createToolGate', function () {
+    const build = groups => createToolGate({
+        claims      : { groups },
+        claimName   : 'groups',
+        serverValue : 'staff'
+    });
+
+    it('reports the whole-server list as serverGranted', function () {
+        assert.strictEqual(build(['staff']).serverGranted, true);
+        assert.strictEqual(build(['media']).serverGranted, false);
+    });
+
+    it('requires both the server list and the tool list', function () {
+        // server: staff, tool B: media, admin: admin — the worked example from the plan.
+        const staff = build(['staff']);
+        assert.strictEqual(staff.allows(''), true);          // tool A, unconstrained
+        assert.strictEqual(staff.allows('media'), false);    // tool B
+        assert.strictEqual(staff.allows('admin'), false);    // admin tools
+
+        const both = build(['staff', 'media']);
+        assert.strictEqual(both.allows(''), true);
+        assert.strictEqual(both.allows('media'), true);
+
+        const admin = build(['staff', 'admin']);
+        assert.strictEqual(admin.allows(''), true);
+        assert.strictEqual(admin.allows('admin'), true);
+    });
+
+    it('denies everything when the server list is not cleared, however open the tool', function () {
+        const media = build(['media']);
+        assert.strictEqual(media.allows(''), false);
+        assert.strictEqual(media.allows('media'), false);
+        assert.strictEqual(build(['guest']).allows(''), false);
+    });
+
+    it('applies only the tool list when the server list is empty', function () {
+        const gate = claims => createToolGate({ claims, claimName: 'groups', serverValue: '' });
+        assert.strictEqual(gate({ groups: ['media'] }).serverGranted, true);
+        assert.strictEqual(gate({ groups: ['media'] }).allows(''), true);
+        assert.strictEqual(gate({ groups: ['media'] }).allows('media'), true);
+        assert.strictEqual(gate({ groups: ['guest'] }).allows(''), true);
+        assert.strictEqual(gate({ groups: ['guest'] }).allows('media'), false);
+    });
+
+    it('opens everything when both lists are empty, even without claims', function () {
+        const gate = createToolGate({ claims: null, claimName: 'groups', serverValue: '' });
+        assert.strictEqual(gate.serverGranted, true);
+        assert.strictEqual(gate.allows(''), true);
+        assert.strictEqual(gate.allows('media'), false);
+    });
+});
+
+describe('lib/claim-gate visibleTools', function () {
+    const registry = {
+        open   : { description: 'open tool',   schema: { type: 'object', properties: { a: { type: 'string' } } }, requiredValue: '' },
+        gated  : { description: 'gated tool',  schema: { b: { type: 'number' } },                                 requiredValue: 'media' },
+        hidden : { description: 'hidden tool', schema: null,                                                      requiredValue: 'nope' }
+    };
+    const gate = claims => createToolGate({ claims, claimName: 'groups', serverValue: '' });
+
+    it('lists only the tools the gate permits', function () {
+        assert.deepStrictEqual(visibleTools(registry, gate({ groups: ['media'] })).map(t => t.name),
+            ['open', 'gated']);
+        assert.deepStrictEqual(visibleTools(registry, gate({ groups: ['guest'] })).map(t => t.name),
+            ['open']);
+    });
+
+    it('passes an object schema through untouched', function () {
+        const [open] = visibleTools(registry, gate({ groups: ['guest'] }));
+        assert.deepStrictEqual(open.inputSchema, { type: 'object', properties: { a: { type: 'string' } } });
+        assert.strictEqual(open.description, 'open tool');
+    });
+
+    it('wraps a bare properties map, and a missing schema, into an object schema', function () {
+        const tools = visibleTools(registry, gate({ groups: ['media', 'nope'] }));
+        const byName = Object.fromEntries(tools.map(t => [t.name, t]));
+        assert.deepStrictEqual(byName.gated.inputSchema, { type: 'object', properties: { b: { type: 'number' } } });
+        assert.deepStrictEqual(byName.hidden.inputSchema, { type: 'object', properties: {} });
+    });
+
+    it('tolerates an empty registry', function () {
+        assert.deepStrictEqual(visibleTools({}, gate({ groups: [] })), []);
+        assert.deepStrictEqual(visibleTools(undefined, gate({ groups: [] })), []);
+    });
+});

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -102,30 +102,3 @@ describe('lib/common createThrottledQueue', function () {
         assert.deepStrictEqual(sent, ['a'], 'only the immediate send happens');
     });
 });
-
-describe('lib/common claimSatisfied', function () {
-    it('opens the gate when no value is required', function () {
-        // Empty value = any authenticated caller; claims are irrelevant, even when absent.
-        assert.strictEqual(common.claimSatisfied({ groups: [] }, 'groups', ''), true);
-        assert.strictEqual(common.claimSatisfied(null, 'groups', ''), true);
-    });
-
-    it('rejects when a value is required but no claims are present', function () {
-        assert.strictEqual(common.claimSatisfied(null, 'groups', 'admin'), false);
-        assert.strictEqual(common.claimSatisfied(undefined, 'groups', 'admin'), false);
-    });
-
-    it('matches a value inside an array claim', function () {
-        assert.strictEqual(common.claimSatisfied({ groups: ['user', 'admin'] }, 'groups', 'admin'), true);
-        assert.strictEqual(common.claimSatisfied({ groups: ['user'] }, 'groups', 'admin'), false);
-    });
-
-    it('matches a scalar claim by strict equality', function () {
-        assert.strictEqual(common.claimSatisfied({ role: 'admin' }, 'role', 'admin'), true);
-        assert.strictEqual(common.claimSatisfied({ role: 'editor' }, 'role', 'admin'), false);
-    });
-
-    it('rejects when the claim is missing from an otherwise valid token', function () {
-        assert.strictEqual(common.claimSatisfied({ sub: 'u1' }, 'groups', 'admin'), false);
-    });
-});

--- a/test/mcp-rpc.test.js
+++ b/test/mcp-rpc.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const assert = require('node:assert');
+const { handleRpc } = require('../lib/mcp-rpc');
+// hal2 keeps its admin catalog in core/mcp-tools.js rather than a lib/admin-tools module,
+// so the dispatcher is exercised against the real get_flow/deploy_flow set.
+const { MCP_TOOLS_ADMIN: TOOLS, MCP_ADMIN_TOOL_NAMES: TOOL_NAMES } = require('../core/mcp-tools');
+
+// Deliberately a plain object (not null-prototype): handleRpc must not resolve
+// caller-supplied names through the prototype chain regardless of registry flavour.
+function registry() {
+    return {
+        open  : { description: 'open tool',  schema: { type: 'object', properties: {} }, timeoutMs: 5000, requiredValue: '' },
+        gated : { description: 'gated tool', schema: { type: 'object', properties: {} }, timeoutMs: 5000, requiredValue: 'media' }
+    };
+}
+
+function deps(overrides = {}) {
+    return Object.assign({
+        serverName        : 'test-server',
+        serverVersion     : '9.9.9',
+        instructions      : '',
+        requiredClaim     : 'groups',
+        requiredValue     : '',
+        adminToolsEnabled : false,
+        adminRequiredValue: 'admin',
+        adminTools        : { TOOLS, TOOL_NAMES, callTool: async () => 'admin ok' },
+        tools             : registry(),
+        callTool          : async () => 'tool ok'
+    }, overrides);
+}
+
+const claims = groups => ({ sub: 'u', groups });
+
+const call = (name, d) => handleRpc({ id: 1, method: 'tools/call', params: { name } }, d.claims, d.deps);
+
+describe('lib/mcp-rpc initialize', function () {
+    it('lists visible tool names, server info and no-store caching', async function () {
+        const out = await handleRpc({ id: 1, method: 'initialize' }, claims(['media']), deps());
+        assert.strictEqual(out.status, 200);
+        assert.deepStrictEqual(out.headers, { 'Cache-Control': 'no-store' });
+        assert.strictEqual(out.body.result.serverInfo.version, '9.9.9');
+        assert.strictEqual(out.body.result.instructions, 'Available tools: open, gated.');
+    });
+
+    it('prefixes configured instructions and hides gated tools from unqualified callers', async function () {
+        const out = await handleRpc({ id: 1, method: 'initialize' }, claims(['guest']),
+            deps({ instructions: 'Be nice.' }));
+        assert.strictEqual(out.body.result.instructions, 'Be nice. Available tools: open.');
+    });
+
+    it('names no tools at all when the server list is not cleared', async function () {
+        const out = await handleRpc({ id: 1, method: 'initialize' }, claims(['guest']),
+            deps({ requiredValue: 'staff' }));
+        assert.strictEqual(out.body.result.instructions, '');
+    });
+
+    it('includes admin tool names only for admin-gated callers', async function () {
+        const on  = await handleRpc({ id: 1, method: 'initialize' }, claims(['admin']),
+            deps({ adminToolsEnabled: true }));
+        assert.ok(on.body.result.instructions.includes('get_flow'));
+        const off = await handleRpc({ id: 1, method: 'initialize' }, claims(['media']),
+            deps({ adminToolsEnabled: true }));
+        assert.ok(!off.body.result.instructions.includes('get_flow'));
+    });
+});
+
+describe('lib/mcp-rpc protocol plumbing', function () {
+    it('acks notifications/initialized with a bodyless 204', async function () {
+        const out = await handleRpc({ method: 'notifications/initialized' }, claims([]), deps());
+        assert.strictEqual(out.status, 204);
+        assert.strictEqual(out.body, undefined);
+    });
+
+    it('answers ping with an empty result', async function () {
+        const out = await handleRpc({ id: 7, method: 'ping' }, claims([]), deps());
+        assert.deepStrictEqual(out.body, { jsonrpc: '2.0', id: 7, result: {} });
+    });
+
+    it('echoes the request id, defaulting to null', async function () {
+        const out = await handleRpc({ method: 'nope' }, claims([]), deps());
+        assert.strictEqual(out.body.id, null);
+        assert.strictEqual(out.body.error.code, -32601);
+    });
+
+    it('rejects unknown methods and a missing body without throwing', async function () {
+        const out = await handleRpc(undefined, claims([]), deps());
+        assert.strictEqual(out.body.error.code, -32601);
+    });
+});
+
+describe('lib/mcp-rpc tools/list', function () {
+    it('filters by the per-tool gate', async function () {
+        const out = await handleRpc({ id: 1, method: 'tools/list' }, claims(['guest']), deps());
+        assert.deepStrictEqual(out.body.result.tools.map(t => t.name), ['open']);
+    });
+
+    it('is empty when the server list is not cleared, whatever the tool lists say', async function () {
+        const out = await handleRpc({ id: 1, method: 'tools/list' }, claims(['media']),
+            deps({ requiredValue: 'staff' }));
+        assert.deepStrictEqual(out.body.result.tools, []);
+    });
+
+    it('appends admin tools only when enabled and admin-gated', async function () {
+        const d = deps({ adminToolsEnabled: true });
+        const admin = await handleRpc({ id: 1, method: 'tools/list' }, claims(['admin']), d);
+        assert.deepStrictEqual(admin.body.result.tools.map(t => t.name),
+            ['open', 'get_flow', 'deploy_flow']);
+        const plain = await handleRpc({ id: 1, method: 'tools/list' }, claims(['media']), d);
+        assert.deepStrictEqual(plain.body.result.tools.map(t => t.name), ['open', 'gated']);
+    });
+});
+
+describe('lib/mcp-rpc tools/call', function () {
+    it('denies at the server gate with the server-level message', async function () {
+        const out = await call('open', { claims: claims(['guest']), deps: deps({ requiredValue: 'staff' }) });
+        assert.strictEqual(out.body.result.isError, true);
+        assert.ok(out.body.result.content[0].text.includes('use this server'));
+    });
+
+    it('denies at the per-tool gate, naming the tool', async function () {
+        const out = await call('gated', { claims: claims(['guest']), deps: deps() });
+        assert.strictEqual(out.body.result.isError, true);
+        assert.ok(out.body.result.content[0].text.includes('"gated" tool requires a permission'));
+    });
+
+    it('dispatches an allowed call and wraps a string result', async function () {
+        const seen = [];
+        const d = deps({ callTool: async (name, timeoutMs, args) => { seen.push([name, timeoutMs, args]); return 'did it'; } });
+        const out = await handleRpc({ id: 1, method: 'tools/call', params: { name: 'open', arguments: { a: 1 } } },
+            claims(['guest']), d);
+        assert.deepStrictEqual(out.body.result.content, [{ type: 'text', text: 'did it' }]);
+        assert.deepStrictEqual(seen, [['open', 5000, { a: 1 }]]);
+    });
+
+    it('passes an array result through as the content array', async function () {
+        const blocks = [{ type: 'text', text: 'x' }, { type: 'image', data: '...' }];
+        const out = await call('open', { claims: claims([]), deps: deps({ callTool: async () => blocks }) });
+        assert.deepStrictEqual(out.body.result.content, blocks);
+        assert.strictEqual(out.body.result.isError, undefined);
+    });
+
+    it('reports a timeout as a tool result, not a protocol error', async function () {
+        const out = await call('open', { claims: claims([]), deps: deps({ callTool: async () => { throw new Error('timeout'); } }) });
+        assert.deepStrictEqual(JSON.parse(out.body.result.content[0].text), { error: 'Tool timed out: open' });
+    });
+
+    it('returns -32601 for unknown tools, including prototype-chain names', async function () {
+        for (const name of ['missing', '__proto__', 'constructor', 'hasOwnProperty']) {
+            const out = await call(name, { claims: claims([]), deps: deps() });
+            assert.strictEqual(out.body.error && out.body.error.code, -32601, name);
+        }
+    });
+
+    it('hides admin tools entirely when disabled', async function () {
+        const out = await call('get_flow', { claims: claims(['admin']), deps: deps() });
+        assert.strictEqual(out.body.error.code, -32601);
+    });
+
+    it('re-checks the admin gate on every call', async function () {
+        const out = await call('get_flow', { claims: claims(['media']), deps: deps({ adminToolsEnabled: true }) });
+        assert.strictEqual(out.body.result.isError, true);
+        assert.ok(out.body.result.content[0].text.includes('admin privileges'));
+    });
+
+    it('runs an admin tool for a qualified caller', async function () {
+        const out = await call('get_flow', { claims: claims(['admin']), deps: deps({ adminToolsEnabled: true }) });
+        assert.deepStrictEqual(out.body.result.content, [{ type: 'text', text: 'admin ok' }]);
+    });
+
+    it('maps an admin rpcCode error to a JSON-RPC error', async function () {
+        const boom = Object.assign(new Error('Invalid flow id'), { rpcCode: -32602 });
+        const d = deps({ adminToolsEnabled: true,
+            adminTools: { TOOLS, TOOL_NAMES, callTool: async () => { throw boom; } } });
+        const out = await call('deploy_flow', { claims: claims(['admin']), deps: d });
+        assert.deepStrictEqual(out.body.error, { code: -32602, message: 'Invalid flow id' });
+    });
+});

--- a/test/mcp-tools.test.js
+++ b/test/mcp-tools.test.js
@@ -2,7 +2,8 @@
 
 const assert = require('node:assert');
 const {
-    MCP_TOOLS, MCP_TOOLS_ADMIN, MCP_ADMIN_TOOL_NAMES, expandHaTypeFilter
+    MCP_TOOLS, MCP_TOOLS_ADMIN, MCP_ADMIN_TOOL_NAMES,
+    MCP_READ_TOOL_NAMES, MCP_WRITE_TOOL_NAMES, toolClass, expandHaTypeFilter
 } = require('../core/mcp-tools');
 
 describe('core/mcp-tools catalog', function () {
@@ -31,6 +32,39 @@ describe('core/mcp-tools catalog', function () {
         for (const t of MCP_TOOLS_ADMIN) {
             assert.ok(!regular.has(t.name), t.name + ' is both admin and regular');
         }
+    });
+
+    it('every catalog tool is classified as read or write', function () {
+        // The guard that matters: adding a tool to MCP_TOOLS without classifying it fails
+        // here rather than silently landing on whichever gate happens to catch it.
+        const missing = MCP_TOOLS.map(t => t.name)
+            .filter(n => !MCP_READ_TOOL_NAMES.has(n) && !MCP_WRITE_TOOL_NAMES.has(n));
+        assert.deepStrictEqual(missing, [], 'unclassified: ' + missing.join(', '));
+    });
+
+    it('the three classes are disjoint', function () {
+        for (const n of MCP_READ_TOOL_NAMES) {
+            assert.ok(!MCP_WRITE_TOOL_NAMES.has(n), n + ' is both read and write');
+            assert.ok(!MCP_ADMIN_TOOL_NAMES.has(n), n + ' is both read and admin');
+        }
+        for (const n of MCP_WRITE_TOOL_NAMES) {
+            assert.ok(!MCP_ADMIN_TOOL_NAMES.has(n), n + ' is both write and admin');
+        }
+    });
+
+    it('classifies control_light as a write, though it is not in the catalog', function () {
+        // An undocumented alias of set_light that the dispatcher accepts. Omitting it would
+        // let a read-only token switch lights.
+        assert.ok(!MCP_TOOLS.some(t => t.name === 'control_light'));
+        assert.strictEqual(toolClass('control_light'), 'write');
+        assert.strictEqual(toolClass('set_light'), 'write');
+    });
+
+    it('toolClass fails closed for anything it does not know', function () {
+        assert.strictEqual(toolClass('some_future_tool'), 'write');
+        assert.strictEqual(toolClass(''), 'write');
+        assert.strictEqual(toolClass('get_state'), 'read');
+        assert.strictEqual(toolClass('deploy_flow'), 'admin');
     });
 
     it('expandHaTypeFilter returns a Set that always contains the input key', function () {

--- a/test/tool-gate.test.js
+++ b/test/tool-gate.test.js
@@ -1,0 +1,106 @@
+'use strict';
+// The read/write gate as the Event handler builds it. buildGate() itself lives inside the
+// node constructor and needs a running Node-RED, so the composition is reproduced here from
+// the same two primitives it uses — claim-gate and toolClass. What is being pinned is the
+// policy: which tool classes clear which value list, and what the empty defaults mean.
+
+const assert = require('node:assert');
+const { createToolGate } = require('../lib/claim-gate');
+const { toolClass, MCP_TOOLS } = require('../core/mcp-tools');
+
+// Mirrors buildGate() in core/eventhandler.js.
+function buildGate(claims, { claimName = 'groups', readValue = '', writeValue = '' } = {}) {
+    const gate = createToolGate({ claims, claimName, serverValue: readValue });
+    return {
+        allows(toolName) {
+            if (!gate.serverGranted) { return false; }
+            return toolClass(toolName) === 'write' ? gate.allows(writeValue) : true;
+        },
+        allowsValue: list => gate.allows(list)
+    };
+}
+
+const READER  = { groups: ['family'] };
+const WRITER  = { groups: ['family', 'ops'] };
+const OUTSIDE = { groups: ['guest'] };
+
+describe('read/write tool gate', function () {
+    const opts = { readValue: 'family', writeValue: 'ops' };
+
+    it('lets a read-only token read but not write', function () {
+        const g = buildGate(READER, opts);
+        assert.strictEqual(g.allows('get_state'), true);
+        assert.strictEqual(g.allows('get_all_states'), true);
+        assert.strictEqual(g.allows('set_light'), false);
+        assert.strictEqual(g.allows('activate_scene'), false);
+    });
+
+    it('lets a token holding both lists do everything', function () {
+        const g = buildGate(WRITER, opts);
+        assert.strictEqual(g.allows('get_state'), true);
+        assert.strictEqual(g.allows('set_light'), true);
+    });
+
+    it('refuses everything to a token that clears neither', function () {
+        const g = buildGate(OUTSIDE, opts);
+        assert.strictEqual(g.allows('get_state'), false);
+        assert.strictEqual(g.allows('set_light'), false);
+    });
+
+    it('closes the write gate against the control_light alias', function () {
+        // The alias the dispatcher accepts but the catalog does not list. If the gate let it
+        // through, a read-only token could switch lights by asking for it by the other name.
+        const g = buildGate(READER, opts);
+        assert.strictEqual(g.allows('control_light'), false);
+        assert.strictEqual(buildGate(WRITER, opts).allows('control_light'), true);
+    });
+
+    it('treats an unknown tool as a write', function () {
+        assert.strictEqual(buildGate(READER, opts).allows('some_future_tool'), false);
+        assert.strictEqual(buildGate(WRITER, opts).allows('some_future_tool'), true);
+    });
+
+    it('keeps read tools that live in the control dispatcher on the read side', function () {
+        // get_scenes and get_alerts are handled by dispatchControlTools but only observe.
+        const g = buildGate(READER, opts);
+        assert.strictEqual(g.allows('get_scenes'), true);
+        assert.strictEqual(g.allows('get_alerts'), true);
+    });
+
+    it('empty defaults leave every catalog tool reachable', function () {
+        // The upgrade path: an existing install has neither field set and must behave
+        // exactly as it did before the gates existed.
+        const g = buildGate(READER);
+        for (const t of MCP_TOOLS) {
+            assert.strictEqual(g.allows(t.name), true, t.name + ' should be reachable');
+        }
+        // …and so should a caller with no claims at all.
+        assert.strictEqual(buildGate(null).allows('set_light'), true);
+    });
+
+    it('a write list alone still gates writes while reads stay open', function () {
+        const g = buildGate(READER, { writeValue: 'ops' });
+        assert.strictEqual(g.allows('get_state'), true);
+        assert.strictEqual(g.allows('set_light'), false);
+        assert.strictEqual(buildGate(WRITER, { writeValue: 'ops' }).allows('set_light'), true);
+    });
+
+    it('accepts comma-separated any-of lists', function () {
+        const g = buildGate({ groups: ['ops'] }, { readValue: 'family,ops', writeValue: 'ops,admin' });
+        assert.strictEqual(g.allows('get_state'), true);
+        assert.strictEqual(g.allows('set_light'), true);
+        // A single configured value keeps behaving as it did before lists existed.
+        assert.strictEqual(buildGate({ groups: ['ops'] }, { readValue: 'ops' }).allows('get_state'), true);
+        assert.strictEqual(buildGate({ groups: ['x'] }, { readValue: 'ops' }).allows('get_state'), false);
+    });
+
+    it('gates dynamic tools on their own value, on top of the read list', function () {
+        const g = buildGate(READER, opts);
+        assert.strictEqual(g.allowsValue(''), true);          // no constraint of its own
+        assert.strictEqual(g.allowsValue('family'), true);
+        assert.strictEqual(g.allowsValue('ops'), false);      // reader lacks it
+        assert.strictEqual(buildGate(WRITER, opts).allowsValue('ops'), true);
+        // The server list still applies even when the tool asks for nothing.
+        assert.strictEqual(buildGate(OUTSIDE, opts).allowsValue(''), false);
+    });
+});


### PR DESCRIPTION
Ports the access-gate work that `node-red-contrib-mcp-server` gained after it was extracted from
hal2, and adds a read/write split for hal2's own built-in tool catalog. Until now a token that
could read device state could also switch every light in the house — the only per-tool distinction
that existed was `MCP_ADMIN_TOOL_NAMES`.

## Access model

One **claim name** on the Event handler carries three comma-separated **any-of** value lists,
combined with AND:

| Gate | Covers | Default |
|---|---|---|
| Read tools | `get_all_states`, `get_state`, `get_history`, `get_scenes`, `get_presence`, `get_alerts`, `analyze_patterns` | empty — any authenticated caller |
| Write tools | `set_light`, `control_device`, `control_fan`, `control_cover`, `control_spa`, `control_climate`, `activate_scene` | empty — same as read |
| Admin tools | `get_flow`, `deploy_flow` | `admin` |

The read list is the floor; writes are checked on top of it, so `read = family` / `write = ops`
lets the household see everything while only ops can change anything. **All new fields default to
empty**, which is no constraint, so an existing install behaves exactly as before.

Tools a caller cannot use are absent from `tools/list` and from the `initialize` blurb rather than
advertised and then refused. A direct call to a hidden tool returns an MCP tool result with
`isError: true` and a readable reason, so the model is told why instead of getting a generic
"tool execution failed".

## Three findings that shaped it

- **`control_light` is an undocumented alias of `set_light`** that the dispatcher accepts but the
  catalog does not list. A write gate keyed on a name set has to include it or it is a clean
  bypass. Pinned by its own test.
- **Read/write cannot be derived from dispatcher membership** — `get_scenes` and `get_alerts` live
  in `dispatchControlTools` but only observe. The classification is an explicit set.
- **A tool in neither set is treated as a write**, so a future addition that nobody classifies
  fails closed instead of slipping through ungated.

## Scope decision: MCP only

Gates are enforced on the MCP surface, where claims are cryptographically verified. `hal2Api`
reads `msg.claims` straight off the message, which any flow can set, so gating it would be
decoration rather than a boundary; it keeps its own local *Allow admin tools* checkbox. The gate
therefore travels in `opts` through `node.callTool` — the single choke point both surfaces reach —
rather than being derived from the claims.

## Ported verbatim

`lib/claim-gate.js` and `lib/mcp-rpc.js` are byte-identical to their upstream copies, which is
what keeps future fixes a `cp` away in either direction. The standalone `hal2MCPServer` route is
rewired onto `handleRpc`, replacing ~90 lines of inline dispatch. The embedded `/mcp` route keeps
its own dispatch deliberately: its static, hardware-filtered catalog does not fit `handleRpc`'s
registry shape, and generalizing it would end the byte-identical portability.

`claimSatisfied` is deleted now that both callers use `createToolGate`.

**Nested claim paths**: a dotted claim name such as `realm_access.roles` is walked as a path when
no literal key of that name exists, so Keycloak-style nested roles work. A literal key always
wins, so PocketID's flat `groups` is untouched.

## Hardening

- `Object.create(null)` for the tool registry and pending-call map. Caller-supplied names like
  `__proto__` previously resolved through the prototype chain, past the "Unknown tool" check, into
  a 30-second hang.
- Duplicate tool-name warning at registration; ownership-checked `unregisterMCPTool`.
- Owner-tagged route removal, so partial-deploying one of two servers sharing a path no longer
  strips its sibling's route.
- Configurable `localDebugGroups` — `mcp-auth` already accepted it but nothing supplied it, so the
  debug token was permanently `admin` and the gates could not be exercised locally.

## Editor and docs

The claim field moved out of the admin section, which is hidden whenever admin tools are off — the
read/write gates need the same claim. `hal2MCPIn` gained a per-tool list with a live tip that reads
the selected server's actual claim name. `docs/API.md` now tags every tool read/write/admin.

## Testing

183 passing, up from 175 — including 19 borrowed claim-gate tests, 21 borrowed RPC-dispatcher
tests with the prototype-chain regression, and 10 new gate-policy tests covering the
`control_light` alias, unknown-tool-is-write, and empty defaults reaching everything.

Verified live against the running instance: routes register cleanly, the embedded endpoint and the
standalone server both answer real OAuth-authenticated calls after the rewire, and a read-only
token is correctly refused write tools while keeping `get_scenes`/`get_alerts`.
