### PR TITLE
Groups get a value of their own

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,37 @@ Take a look at the example flows and Thing definitions in the https://github.com
 
 ## Groups
 
-Control several Things at once with **Groups**. A group's identity — name, HAType, and a rate limit — lives in a registry on the **Event handler** (*Groups* tab), while membership is set per Item on each Thing (the *Groups* section of the Thing editor: pick an Item, pick a group). A group can then be used as a target in an **Action** node (broadcast a command to every member, paced by the rate limit) or as a source in an **Event** node (fire when any member changes, carrying which Thing/Item actually changed). Each group in the registry has an **info button** that lists its current members.
+Control and observe several Things at once with **Groups**. A group's identity — name, HAType, value function and rate limit — lives in a registry on the **Event handler** (*Groups* tab), while membership is set per Item on each Thing (the *Groups* section of the Thing editor: pick an Item, pick a group). A group can then be used as a target in an **Action** node, broadcasting a command to every member paced by the rate limit. Each group in the registry has an **info button** that lists its current members.
+
+### A group's own value
+
+Give a group a **Value** and it stops being write-only: it gains a state of its own, computed from its members, that **Value**, **Gate**, **Event** and **Bayes** nodes can read exactly like an Item's. *Temperatur inne → average* is one number for the whole house; *Alla lampor → any true* is one boolean for "is anything on".
+
+| Function | Result |
+|---|---|
+| `latest` | the most recently updated member's value, whatever its type |
+| `min` / `max` | the lowest / highest value |
+| `average` / `median` / `sum` | the mean, the middle value, everything added up |
+| `range` | highest minus lowest — the spread across the group |
+| `any true` / `all true` | at least one / every member is `true` |
+| `any false` / `all false` | at least one member is `false` / none is `true` |
+| `count true` / `count false` | how many members are `true` / `false` — compare it in a Gate |
+| `percent true` | the share that are `true`, 0–100 |
+
+Four rules decide what goes into the calculation:
+
+- **Only members with a state.** A command-only Item has nothing to contribute, and the Value field is disabled for a group that has no stateful members at all.
+- **Only members whose Thing is alive.** A device that has dropped off the network is left out rather than voting with the value it had before it went quiet — so `any true` goes false when the last reachable lamp disappears, instead of reporting a light that may well be dark.
+- **Only values of the right kind.** The numeric functions skip anything that is not a number (a boolean member never counts as 1), and the boolean functions are strict about `true` / `false` — hal2 normalises `ON`/`1` in the ThingType's ingress function, so by the time a state reaches a group it is a real boolean or it is not one at all.
+- **Nothing eligible means no value.** A group with no live member reporting reads as *undefined*, not `0` or `false`, so a silent group can never be mistaken for a real "off" in a Gate.
+
+A group behaves like an Item in every other respect: it emits on each member update carrying `state` and `laststate`, so an **Event** node's *only on change* filter works the same as it does for a Thing, and `msg.member` says which member moved it. A group's value is derived, so it is never written to the history database and a **Value** node can only read it — use an **Action** node to command a group.
 
 A group has a **HAType** that sets the command contract for its members. Compatibility is directional: `Switch` and `Light` are interchangeable (both are boolean On/Off), and a `Dimmer` item may also join an On/Off group (turning a dimmer off is well-defined) — but a switch or light cannot join a `Dimmer` group, since an On/Off device can't honour a 0–100 level. The Thing editor only offers compatible groups for each Item, and the Event handler only offers HATypes its existing members can all honour. For genuinely mixed groups there is an **Other** type that accepts any Item.
 
-Groups replace the old standalone `hal2Group` node. Existing flows keep working — the Event handler folds legacy group nodes in automatically — but you should run `node tools/migrate-groups.js <flows.json>` to make the move permanent and then remove the deprecated nodes. The migration preserves group ids, so existing Action/Event references keep resolving untouched.
+A group without a Value stays exactly what it was: a command target, invisible to the reading nodes.
+
+Groups replace the old standalone `hal2Group` node. Existing flows keep working — the Event handler folds legacy group nodes in automatically, though they are command-only until migrated — but you should run `node tools/migrate-groups.js <flows.json>` to make the move permanent and then remove the deprecated nodes. The migration preserves group ids, so existing Action/Event references keep resolving untouched.
 
 ## AI & external control
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Give a group a **Value** and it stops being write-only: it gains a state of its 
 Four rules decide what goes into the calculation:
 
 - **Only members with a state.** A command-only Item has nothing to contribute, and the Value field is disabled for a group that has no stateful members at all.
-- **Only members whose Thing is alive.** A device that has dropped off the network is left out rather than voting with the value it had before it went quiet — so `any true` goes false when the last reachable lamp disappears, instead of reporting a light that may well be dark.
+- **No offline members.** A device that has dropped off the network is left out rather than voting with the value it had before it went quiet — so `any true` goes false when the last reachable lamp disappears, instead of reporting a light that may well be dark.
 - **Only values of the right kind.** The numeric functions skip anything that is not a number (a boolean member never counts as 1), and the boolean functions are strict about `true` / `false` — hal2 normalises `ON`/`1` in the ThingType's ingress function, so by the time a state reaches a group it is a real boolean or it is not one at all.
 - **Nothing eligible means no value.** A group with no live member reporting reads as *undefined*, not `0` or `false`, so a silent group can never be mistaken for a real "off" in a Gate.
 

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -414,7 +414,7 @@
                         groupSel.append($("<option></option>").val(g.id).text(g.name));
                     });
                     if (!groupsList.length) {
-                        groupSel.append($("<option></option>").val('').text('no groups with a value'));
+                        groupSel.append($("<option></option>").val('').text('- no groups with a value -'));
                     }
                     groupSel.val(step.group || (groupsList[0] && groupsList[0].id) || '');
                     var propWrap = $('<span/>', { class: "bs-prop-wrap",

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -470,6 +470,13 @@
                     $('<div/>', { class: "bs-days-hint",
                         style: "margin-left:50px; margin-top:3px; font-size:0.9em;" }).appendTo(stepDiv).hide();
 
+                    // What a group step is actually reading, last in the step so it sits under
+                    // the timing line. The 50px lead matches the column the selects start in;
+                    // max-width goes because form-tips otherwise caps itself at 450px.
+                    var groupTip = $('<div/>', { class: "form-tips bs-group-tip",
+                        style: "margin-left:50px; margin-right:34px; margin-top:6px; max-width:none; white-space:normal;" })
+                        .appendTo(stepDiv).hide();
+
                     var windowSpan = $('<span/>', { class: "bs-window-span" }).appendTo(timing);
                     $('<span/>', { class: "bs-window-lead" }).appendTo(windowSpan).text('within ');
                     $('<input/>', { class: "bs-window", type: "number", min: "1", step: "any", style: "width:55px;" })
@@ -516,12 +523,23 @@
                     };
                     opSel.change(opHandler);
 
+                    var syncGroupTip = function() {
+                        var g = groupsList.filter(function(x) { return x.id === groupSel.val(); })[0];
+                        var show = srcSel.val() === 'group' && !!g;
+                        if (show) {
+                            groupTip.html($('<small/>').text('Value: ' + window.hal2GroupAggregate.label(g.aggregate)));
+                        }
+                        groupTip.toggle(show);
+                    };
+                    groupSel.change(syncGroupTip);
+
                     var srcHandler = function() {
                         var src = srcSel.val();
                         thingWrap.toggle(src === 'thing');
                         groupWrap.toggle(src === 'group');
                         propWrap.toggle(src !== 'thing' && src !== 'group' && src !== 'time');
                         timeWrap.toggle(src === 'time');
+                        syncGroupTip();
                         syncOperatorOptions();
                     };
                     // For a time step resolveState yields a boolean, so the existing

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -436,6 +436,13 @@
                             refreshRuleView(ruleContainer);
                         });
 
+                    // What a group step is actually reading, directly under the source line as
+                    // in the other nodes. The 50px lead matches the column the selects start in;
+                    // max-width goes because form-tips otherwise caps itself at 450px.
+                    var groupTip = $('<div/>', { class: "form-tips bs-group-tip",
+                        style: "margin-left:50px; margin-right:34px; margin-top:6px; max-width:none; box-sizing:border-box; white-space:normal;" })
+                        .appendTo(stepDiv).hide();
+
                     // Line 2 — the condition, and when it has to hold.
                     var line2 = $('<div/>', { style: "display:flex; align-items:center; margin-top:4px;" }).appendTo(stepDiv);
                     indent(line2);
@@ -469,13 +476,6 @@
                     // Read-back of the configured window, on its own line under the weekdays.
                     $('<div/>', { class: "bs-days-hint",
                         style: "margin-left:50px; margin-top:3px; font-size:0.9em;" }).appendTo(stepDiv).hide();
-
-                    // What a group step is actually reading, last in the step so it sits under
-                    // the timing line. The 50px lead matches the column the selects start in;
-                    // max-width goes because form-tips otherwise caps itself at 450px.
-                    var groupTip = $('<div/>', { class: "form-tips bs-group-tip",
-                        style: "margin-left:50px; margin-right:34px; margin-top:6px; max-width:none; white-space:normal;" })
-                        .appendTo(stepDiv).hide();
 
                     var windowSpan = $('<span/>', { class: "bs-window-span" }).appendTo(timing);
                     $('<span/>', { class: "bs-window-lead" }).appendTo(windowSpan).text('within ');

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -437,11 +437,19 @@
                         });
 
                     // What a group step is actually reading, directly under the source line as
-                    // in the other nodes. The 50px lead matches the column the selects start in;
+                    // in the other nodes. Built with the same flex shape as the lines around it
+                    // rather than fixed margins: the 50px lead is the column the selects start
+                    // in, and the trailing bs-endpad is the remove-button column, which
+                    // refreshRuleView hides for a single-step rule — with a fixed margin the box
+                    // would then stop 34px short of fields that had grown into that space.
                     // max-width goes because form-tips otherwise caps itself at 450px.
+                    var groupTipRow = $('<div/>', { class: "bs-group-tip-row",
+                        style: "display:flex; align-items:center; margin-top:6px;" }).appendTo(stepDiv).hide();
+                    $('<span/>', { style: "flex:0 0 50px;" }).appendTo(groupTipRow);
                     var groupTip = $('<div/>', { class: "form-tips bs-group-tip",
-                        style: "margin-left:50px; margin-right:34px; margin-top:6px; max-width:none; box-sizing:border-box; white-space:normal;" })
-                        .appendTo(stepDiv).hide();
+                        style: "flex:1 1 0; min-width:0; max-width:none; box-sizing:border-box; white-space:normal;" })
+                        .appendTo(groupTipRow);
+                    $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(groupTipRow);
 
                     // Line 2 — the condition, and when it has to hold.
                     var line2 = $('<div/>', { style: "display:flex; align-items:center; margin-top:4px;" }).appendTo(stepDiv);
@@ -529,7 +537,7 @@
                         if (show) {
                             groupTip.html($('<small/>').text('Value: ' + window.hal2GroupAggregate.label(g.aggregate)));
                         }
-                        groupTip.toggle(show);
+                        groupTipRow.toggle(show);
                     };
                     groupSel.change(syncGroupTip);
 

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -1,6 +1,7 @@
 <script type="text/javascript" src="resources/node-red-contrib-hal2/hal.js"></script>
 <script type="text/javascript" src="resources/node-red-contrib-hal2/bayes-scale.js"></script>
 <script type="text/javascript" src="resources/node-red-contrib-hal2/bayes-time.js"></script>
+<script type="text/javascript" src="resources/node-red-contrib-hal2/group-aggregate.js"></script>
 
 <script type="text/x-red" data-template-name="hal2Bayes">
     <div class="form-row">
@@ -105,8 +106,14 @@
     <h3>Rules</h3>
     <p>Everything is a <b>rule</b>, built from steps. Each step names a source and a condition, then
     says <i>when</i> that condition has to hold. A source is normally a <b>thing</b> item, but it can
-    also be a <b>flow</b>, <b>global</b> or <b>env</b> variable &mdash; useful for facts that live
-    elsewhere in the flow, such as "the calendar says we are away" or "guest mode is on".</p>
+    also be a <b>group</b> &mdash; the value a group computes from its members, so "any window is
+    open" or "the average indoor temperature" is one step instead of ten &mdash; or a <b>flow</b>,
+    <b>global</b> or <b>env</b> variable, useful for facts that live elsewhere in the flow, such as
+    "the calendar says we are away" or "guest mode is on".</p>
+    <p>A <b>group</b> behaves exactly like a thing item here: it emits when its value changes, so
+    every timing qualifier below works on it. Only groups that have been given a <b>Value</b> on the
+    Event handler's Groups tab can be chosen, and a group where no live member is reporting reads as
+    no evidence rather than as a false.</p>
     <ul>
         <li><b>now</b> &mdash; a condition, true at that instant. Reads <i>and&hellip;</i></li>
         <li><b>now or soon</b> &mdash; the same, but if it is not true yet the step waits for it until
@@ -278,6 +285,7 @@
             oneditprepare: function() {
                 var node = this;
                 var thingsList = halGetThings(RED, 'status');
+                var groupsList = halGetGroups(RED, $("#node-input-eventHandler").val(), 'value');
 
                 var tabs = RED.tabs.create({
                     id: 'hal2bayes-tabs',
@@ -336,6 +344,7 @@
                 function stepValid(s) {
                     if (!s) { return false; }
                     if (s.src === 'time') { return btime.parseHHMM(s.start) !== null && btime.parseHHMM(s.end) !== null; }
+                    if (s.src === 'group') { return !!s.group; }
                     if (s.src === 'flow' || s.src === 'global' || s.src === 'env') { return !!s.prop; }
                     return !!(s.thing && s.item);
                 }
@@ -392,12 +401,22 @@
                     var line1 = flexRow();
                     $('<span/>', { class: "bs-lead", style: "flex:0 0 50px; font-weight:bold;" }).appendTo(line1);
                     var srcSel = $('<select/>', { class: "bs-src", style: "flex:0 0 130px; min-width:0;" }).appendTo(line1);
-                    [['thing', 'thing'], ['flow', 'flow'], ['global', 'global'], ['env', 'env'], ['time', 'time']]
+                    [['thing', 'thing'], ['group', 'group'], ['flow', 'flow'], ['global', 'global'], ['env', 'env'], ['time', 'time']]
                         .forEach(function(s) { srcSel.append($("<option></option>").val(s[0]).text(s[1])); });
                     var thingWrap = $('<span/>', { class: "bs-thing-wrap",
                         style: "flex:3 1 0; min-width:0; display:flex; margin-left:4px;" }).appendTo(line1);
                     var thingSel = $('<select/>', { class: "bs-thing", style: "flex:5 1 0; min-width:0;" }).appendTo(thingWrap);
                     var itemSel = $('<select/>', { class: "bs-item", style: "flex:3 1 0; min-width:0; margin-left:4px;" }).appendTo(thingWrap);
+                    var groupWrap = $('<span/>', { class: "bs-group-wrap",
+                        style: "flex:3 1 0; min-width:0; display:flex; margin-left:4px;" }).appendTo(line1);
+                    var groupSel = $('<select/>', { class: "bs-group", style: "flex:1 1 0; min-width:0;" }).appendTo(groupWrap);
+                    groupsList.forEach(function(g) {
+                        groupSel.append($("<option></option>").val(g.id).text(g.name));
+                    });
+                    if (!groupsList.length) {
+                        groupSel.append($("<option></option>").val('').text('no groups with a value'));
+                    }
+                    groupSel.val(step.group || (groupsList[0] && groupsList[0].id) || '');
                     var propWrap = $('<span/>', { class: "bs-prop-wrap",
                         style: "flex:3 1 0; min-width:0; margin-left:4px;" }).appendTo(line1);
                     $('<input/>', { class: "bs-prop", type: "text", placeholder: "variable name", style: "width:100%;" })
@@ -500,7 +519,8 @@
                     var srcHandler = function() {
                         var src = srcSel.val();
                         thingWrap.toggle(src === 'thing');
-                        propWrap.toggle(src !== 'thing' && src !== 'time');
+                        groupWrap.toggle(src === 'group');
+                        propWrap.toggle(src !== 'thing' && src !== 'group' && src !== 'time');
                         timeWrap.toggle(src === 'time');
                         syncOperatorOptions();
                     };
@@ -530,13 +550,14 @@
                     opSel.val(step.operator || 'true');
                     opHandler();
 
-                    var src = ['thing', 'flow', 'global', 'env'].indexOf(step.src) >= 0 ? step.src : 'thing';
+                    var src = ['thing', 'group', 'flow', 'global', 'env', 'time'].indexOf(step.src) >= 0 ? step.src : 'thing';
                     srcSel.val(src);
                     patSel.val(step.pattern || 'is');
                     srcHandler();
                     // A saved edge qualifier on a polled source can never fire; say so rather
                     // than silently swapping it.
-                    if (src !== 'thing' && (step.pattern === 'becomes' || step.pattern === 'cycle')) {
+                    if (src !== 'thing' && src !== 'group' && src !== 'time' &&
+                        (step.pattern === 'becomes' || step.pattern === 'cycle')) {
                         RED.notify('hal2Bayes: a ' + src + ' step cannot detect changes — changed it to "now"', 'warning');
                     }
                     return stepDiv;
@@ -567,6 +588,7 @@
                         var step = {
                             src:      src,
                             thing:    el.find('.bs-thing option:selected').val(),
+                            group:    el.find('.bs-group option:selected').val() || '',
                             item:     el.find('.bs-item option:selected').val(),
                             prop:     el.find('.bs-prop').val(),
                             operator: el.find('.bs-op option:selected').val(),
@@ -605,7 +627,7 @@
                         var isTime = src === 'time';
 
                         var allowed = isTime ? ['is']
-                                    : src === 'thing' ? (i === 0 ? ['is', 'becomes', 'cycle'] : ALL_PATTERNS)
+                                    : (src === 'thing' || src === 'group') ? (i === 0 ? ['is', 'becomes', 'cycle'] : ALL_PATTERNS)
                                     : (i === 0 ? ['is'] : ['is', 'isOrBecomes']);
                         var patSel = el.find('.bs-pattern');
                         setPatternOptions(patSel, allowed, patSel.val());

--- a/core/bayes.js
+++ b/core/bayes.js
@@ -52,23 +52,26 @@ module.exports = function(RED) {
                     ? sec(r.halfLife, 1200)
                     : scale.fadeSeconds(r.fade) * 1000;
                 const steps = (r.steps || []).map((s, si) => {
-                    const src = ['thing', 'flow', 'global', 'env', 'time'].indexOf(s.src) >= 0 ? s.src : 'thing';
+                    const src = ['thing', 'group', 'flow', 'global', 'env', 'time'].indexOf(s.src) >= 0 ? s.src : 'thing';
                     let pattern = ['cycle', 'is', 'isOrBecomes', 'becomes'].indexOf(s.pattern) >= 0 ? s.pattern : 'is';
                     // Polled sources have no change event, so an edge on them could only be
-                    // sampled on the tick and would be missed outright between two ticks.
-                    if (src !== 'thing' && (pattern === 'cycle' || pattern === 'becomes')) {
+                    // sampled on the tick and would be missed outright between two ticks. A
+                    // group is not polled — it emits on the bus exactly like a thing — so it
+                    // keeps every pattern.
+                    const polled = src !== 'thing' && src !== 'group';
+                    if (polled && (pattern === 'cycle' || pattern === 'becomes')) {
                         node.warn('A ' + src + ' step cannot detect changes — treating it as a condition');
                         pattern = 'is';
                     }
                     // Nothing can drive a polled source at the head of a rule: there is no
                     // subscription to wake it and no previous step to be "soon" after, so
                     // 'isOrBecomes' there would never fire at all.
-                    if (src !== 'thing' && si === 0 && pattern === 'isOrBecomes') { pattern = 'is'; }
+                    if (polled && si === 0 && pattern === 'isOrBecomes') { pattern = 'is'; }
                     // Waiting for the clock to cross into a window is never useful, so a time
                     // step is always a plain condition wherever it sits.
                     if (src === 'time') { pattern = 'is'; }
                     return {
-                        src, thing: s.thing, item: s.item, prop: s.prop,
+                        src, thing: s.thing, item: s.item, group: s.group, prop: s.prop,
                         start: s.start, end: s.end,
                         days: Array.isArray(s.days) ? s.days.map(Number) : undefined,
                         operator: s.operator, value: s.value, valueType: s.valueType || 'str',
@@ -78,6 +81,7 @@ module.exports = function(RED) {
                     };
                 }).filter(s => {
                     if (s.src === 'thing') { return s.thing && s.item; }
+                    if (s.src === 'group') { return !!s.group; }
                     if (s.src === 'time')  { return bayesTime.parseHHMM(s.start) !== null &&
                                                     bayesTime.parseHHMM(s.end) !== null; }
                     return s.prop;
@@ -113,6 +117,13 @@ module.exports = function(RED) {
         // why they are restricted to condition steps (see the pattern guard above).
         function resolveState(step) {
             switch (step.src) {
+                // The group engine keeps the aggregate; undefined when no live member is
+                // reporting, which the estimator already treats as "no evidence".
+                case 'group': {
+                    const rec = node.eventHandler && typeof node.eventHandler.getGroupState === 'function'
+                        ? node.eventHandler.getGroupState(step.group) : null;
+                    return rec ? rec.state : undefined;
+                }
                 case 'flow':   return node.context().flow.get(step.prop);
                 case 'global': return node.context().global.get(step.prop);
                 case 'env':    return process.env[step.prop];
@@ -162,9 +173,14 @@ module.exports = function(RED) {
         const byThing = {};
         cfg.rules.forEach(rule => {
             rule.steps.forEach((step, i) => {
-                if (step.src !== 'thing') { return; }   // polled sources are read, not subscribed
-                const t = (byThing[step.thing] = byThing[step.thing] || {});
-                (t[step.item] = t[step.item] || []).push({ ruleId: rule.id, stepIndex: i });
+                // Polled sources are read, not subscribed. A group emits on the bus under its
+                // own id and carries one value, so it subscribes exactly like a thing whose
+                // item id happens to be the group id.
+                if (step.src !== 'thing' && step.src !== 'group') { return; }
+                const id   = step.src === 'group' ? step.group : step.thing;
+                const item = step.src === 'group' ? step.group : step.item;
+                const t = (byThing[id] = byThing[id] || {});
+                (t[item] = t[item] || []).push({ ruleId: rule.id, stepIndex: i });
             });
         });
         const subscriptions = [];

--- a/core/event.html
+++ b/core/event.html
@@ -26,6 +26,10 @@
             <button id="thing-filter-button"><i class="fa fa-filter"></i></button>
         </div>
 
+        <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
+            <small id="group-tip"></small>
+        </div>
+
         <div class="form-row" id="thing-filter-div" hidden>
             <label for="thing-filter" id="label-thing-filter"><i class="fa fa-filter"></i> Filter</label>
             <select id="thing-filter" style="width:calc(100% - 170px)"></select>
@@ -317,8 +321,12 @@
                         $("<option value='" + gid + "'>" + gid + "</option>").appendTo("#node-input-item");
                         $("#node-input-item").val(gid);
                     }
+                    var g = groupsList.filter(function(x) { return x.id === gid; })[0];
+                    $("#group-tip").text(g ? 'Value: ' + window.hal2GroupAggregate.label(g.aggregate) : '');
+                    $("#row-group-tip").toggle(!!g);
                     return;
                 }
+                $("#row-group-tip").hide();
 
                 let thing = RED.nodes.node($("#node-input-thing").val());
                 if (typeof thing === 'undefined') { return }

--- a/core/event.html
+++ b/core/event.html
@@ -26,7 +26,7 @@
             <button id="thing-filter-button"><i class="fa fa-filter"></i></button>
         </div>
 
-        <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
+        <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); max-width:none; box-sizing:border-box; margin-bottom:8px;">
             <small id="group-tip"></small>
         </div>
 

--- a/core/event.html
+++ b/core/event.html
@@ -124,7 +124,8 @@
 <script type="text/x-red" data-help-name="hal2Event">
     <p>The Event node is used to initiate a flow when certain <i>Item</i> conditions are met.</p>
     <li><strong>Event handler</strong>: Used for firing events between nodes. Use the same config for all nodes that should be able to communicate.</li>
-    <li><strong>Item/Trigger</strong>: Select which <i>Item</i> and what conditions are to be met for the event to trigger.</li>
+    <li><strong>Category</strong>: A <i>Thing</i> watches one Item, a <i>Type</i> watches the same Item across every Thing of that type, and a <i>Group</i> watches the group's own value. Only groups that have been given a <b>Value</b> on the Event handler's Groups tab can be watched — a command-only group has nothing to observe.</li>
+    <li><strong>Item/Trigger</strong>: Select which <i>Item</i> and what conditions are to be met for the event to trigger. For a group the group <em>is</em> the item: it carries one aggregated value, and the trigger compares that. <code>msg.member</code> tells you which member moved it.</li>
     <li><strong>on change/on update</strong>: If <em>on change</em> is selected the event only triggers if the value really changed, <em>on update</em> triggers every time the value is updated even if the value itself stays the same.</li>
     <li><strong>Output</strong>: Select what value the node should be sending on to the next node when triggered. If <i>event msg</i> is selected, the <i>Item state</i> value is sent. The <code>msg.thing</code>, <code>msg.item</code> and <code>msg.topic</code> from the <i>Thing</i> node is always added to the outgoing <code>msg</code>.</li>
     <li><strong>Topic</strong>: <code>msg.topic</code>, leave blank to get topic from <i>Item</i>.</li>
@@ -171,12 +172,19 @@
         oneditprepare: async function () {
             var operators = halOperators([{ v: "always", t: "always"}]);
 
-            // Check if Thing has been deleted
+            var groupsList = halGetGroups(RED, $("#node-input-eventHandler").val(), 'value');
+
+            // Check if the source has been deleted. A group is not a node — its id lives in the
+            // Event handler's registry — so looking it up with RED.nodes.node() finds nothing and
+            // would wipe a perfectly good configuration every time the dialog opened.
             if (this.thing != 0) {
                 try {
-                    let thing = RED.nodes.node(this.thing);
-                    if (typeof thing === 'undefined') {
-                        console.error('Thing ID '+this.thing+' is missing.');
+                    var stillThere = (this.typeSel === 'hal2Group')
+                        ? groupsList.some(function(g) { return g.id === this.thing; }, this)
+                        : typeof RED.nodes.node(this.thing) !== 'undefined';
+                    if (!stillThere) {
+                        console.error((this.typeSel === 'hal2Group' ? 'Group ' : 'Thing ') + this.thing +
+                                      ' is missing (or no longer has a value).');
                         this.thing = void 0;
                         this.item = void 0;
                         this.typeSel = void 0;
@@ -197,7 +205,6 @@
                 $("#div-error").show();
                 return;
             }  
-            var groupsList = halGetGroups(RED, $("#node-input-eventHandler").val());
             var thingTypeList = halGetThingTypes(RED,thingsList,true);
 
             $('#node-input-rate').spinner({

--- a/core/event.html
+++ b/core/event.html
@@ -248,6 +248,11 @@
                         $("#thing-filter-button").hide();
                         $("#thing-filter-div").hide();
                         $("#node-input-thing").children().remove();
+                        if (groupsList.length === 0) {
+                            // Say why rather than showing an empty box: a group is only
+                            // offered here once it has been given a Value.
+                            $("<option value=''>- no groups with a value -</option>").appendTo("#node-input-thing");
+                        }
                         for (let d in groupsList) {
                             $("<option value='" + groupsList[d].id + "'>" + groupsList[d].name + "</option>").appendTo("#node-input-thing");
                         }

--- a/core/event.js
+++ b/core/event.js
@@ -130,6 +130,16 @@ module.exports = function(RED) {
             if (node.topic != '') {
                 msg.topic = node.topic;
             }
+            // A group is not a node: its context travels on the event itself, so pass it
+            // through whatever the output type is rather than looking anything up.
+            if (node.typeSel === 'hal2Group') {
+                if (event && event.group)  { msg.group  = event.group; }
+                if (event && event.member) { msg.member = event.member; }
+                node.send(msg);
+                node.debug('Event: Group '+thingid);
+                showState();
+                return;
+            }
             const thing = RED.nodes.getNode(thingid);
             if (thing && thing.thingType && thing.thingType.items) {
                 const itm = thing.thingType.items.find(i => i.id === itemid);
@@ -150,8 +160,8 @@ module.exports = function(RED) {
 
         if (node.eventHandler) {
             node.listener = function(thingtypeid, thingid, itemid, event) {
-                // For group sources the engine re-emits with the real member item id,
-                // so the item filter is bypassed — any member change triggers the event.
+                // A group emits under its own id with its own aggregated state, so the item
+                // filter does not apply — the group is the item.
                 if (node.typeSel != 'hal2Group' && itemid != node.item) { return; }
                 if (node.change == '2' && typeof event.laststate == 'undefined') { return; }
                 if (node.change == '1' && event.state === event.laststate) { return; }

--- a/core/eventhandler.html
+++ b/core/eventhandler.html
@@ -1,3 +1,5 @@
+<script type="text/javascript" src="resources/node-red-contrib-hal2/group-aggregate.js"></script>
+
 <script type="text/x-red" data-template-name="hal2EventHandler">
     <div class="form-row tabs-row">
         <ul style="min-width: 600px; margin-bottom: 20px;" id="hal2eh-tabs"></ul>
@@ -37,7 +39,11 @@
         <div id="hal2eh-tab-groups" style="display:none">
             <div class="form-row">
                 <p>Groups let you control and observe several Things at once. Membership is set per item on each
-                Thing; a group's identity lives here. Pick a <b>HAType</b> to keep a group homogeneous — only
+                Thing; a group's identity lives here. Give a group a <b>Value</b> and it gains a state of its own,
+                computed from its members — <i>average</i> over a temperature group, <i>any true</i> over the
+                lights — which Value, Gate, Event and Bayes nodes can then read exactly like a Thing's item.
+                Members whose Thing is offline are left out of the calculation. Pick a <b>HAType</b> to keep a
+                group homogeneous — only
                 items of that type can join. Choose <b>Other / Mixed</b> for a free-form group that accepts any
                 item; then it is your responsibility that the members can handle the broadcast command.</p>
             </div>
@@ -256,7 +262,9 @@
     ThingTypes can reference by id, so logic is defined once instead of copied per type. Each has an
     info button showing which ThingTypes use it.</li>
     <li><strong>Groups</strong>: group items across Things by HAType (e.g. all "light" items) so they
-    can be controlled together; referenced by <code>hal2Action</code> / <code>hal2Event</code>.</li>
+    can be controlled together by <code>hal2Action</code>. Give a group a <b>Value</b> — average, any
+    true, count true, … — and it also gains a state of its own that <code>hal2Value</code>,
+    <code>hal2Gate</code>, <code>hal2Event</code> and <code>hal2Bayes</code> can read like any item.</li>
     <li><strong>History</strong>: optional SQLite logging of item state changes with a retention
     window. Powers the <code>get_history</code> (incl. server-side bucketed downsampling) and
     <code>analyze_patterns</code> tools.</li>
@@ -382,6 +390,8 @@
                     var rowName    = $('<div/>').appendTo(container);
                     var rowDetails = $('<div/>', { style: "margin-top:8px;" }).appendTo(container).hide();
                     var rowType    = $('<div/>', { style: "margin-top:8px;" }).appendTo(rowDetails);
+                    var rowValue   = $('<div/>', { style: "margin-top:8px;" }).appendTo(rowDetails);
+                    var rowValueTip= $('<div/>', { style: "margin-top:4px; margin-left:115px; color:#888; font-size:12px;" }).appendTo(rowDetails);
                     var rowRate    = $('<div/>', { style: "margin-top:8px;" }).appendTo(rowDetails);
                     var rowNotes   = $('<div/>', { style: "margin-top:8px;" }).appendTo(rowDetails);
 
@@ -406,6 +416,8 @@
                         .appendTo(rowName).append(' Group');
                     $('<div/>', { style: "display:inline-block;text-align:left;width:115px;padding-right:10px;box-sizing:border-box;", class: "fa fa-bookmark" })
                         .appendTo(rowType).append(' HAType');
+                    $('<div/>', { style: "display:inline-block;text-align:left;width:115px;padding-right:10px;box-sizing:border-box;", class: "fa fa-calculator" })
+                        .appendTo(rowValue).append(' Value');
                     $('<div/>', { style: "display:inline-block;text-align:left;width:115px;padding-right:10px;box-sizing:border-box;", class: "fa fa-clock-o" })
                         .appendTo(rowRate).append(' Rate limit');
                     $('<div/>', { style: "display:inline-block;text-align:left;width:115px;padding-right:10px;box-sizing:border-box;vertical-align:top;", class: "fa fa-file" })
@@ -477,6 +489,13 @@
                             message += '<br>No things are members of this group.<br>';
                         }
 
+                        var fnNow = $(container).find(".node-config-eh-group-aggregate-property").val();
+                        message += '<br><b>Value</b><br>';
+                        message += fnNow
+                            ? window.hal2GroupAggregate.label(fnNow) +
+                              '<br>Readable by Value, Gate, Event and Bayes nodes.<br>'
+                            : 'No value — this group can be commanded but not read.<br>';
+
                         message += '<br><b>Used in</b>';
                         if (usageRows) {
                             message += '<table style="' + tableStyle + '"><tr><th style="text-align:left;">Type</th><th style="text-align:left;">Name</th><th style="text-align:left;">Workspace</th></tr>' + usageRows + '</table>';
@@ -531,6 +550,66 @@
                         }
                     });
                     haTypeProperty.val(currentHaType);
+
+                    // How many members carry state. A command-only group has nothing to
+                    // aggregate, so the field is offered but disabled rather than hidden —
+                    // the empty select would otherwise look like a bug.
+                    var stateMembers = (function() {
+                        var n = 0;
+                        var gid = idProperty.val();
+                        var things = RED.nodes.filterNodes({ type: "hal2Thing" });
+                        for (var t in things) {
+                            var thing = RED.nodes.node(things[t].id);
+                            if (!thing || !Array.isArray(thing.groups)) { continue; }
+                            var tt = null;
+                            try { tt = RED.nodes.node(thing.thingType); } catch (err) {}
+                            for (var g in thing.groups) {
+                                if (thing.groups[g].group !== gid) { continue; }
+                                if (thing.groups[g].item === '1') { continue; }   // heartbeat is a filter, not a value
+                                if (tt && Array.isArray(tt.items)) {
+                                    var it = tt.items.find(function(x) { return x.id === thing.groups[g].item; });
+                                    if (it && halStatusItem(it)) { n += 1; }
+                                }
+                            }
+                        }
+                        return n;
+                    })();
+
+                    var valueProperty = $('<select/>', { class: "node-config-eh-group-aggregate-property", style: "width:calc(100% - 125px)" })
+                        .appendTo(rowValue);
+                    valueProperty.append($("<option></option>").val('').text('(none — command-only group)'));
+                    (function() {
+                        var ga = window.hal2GroupAggregate;
+                        // Ordered by what this HAType usually wants, never filtered: a mixed
+                        // group may legitimately want to count booleans.
+                        var wanted = ga.kindOf(ga.suggestFor(haTypeProperty.val() || group.haType));
+                        var fns = ga.FUNCTIONS.slice().sort(function(a, b) {
+                            var ra = (a.kind === wanted) ? 0 : (a.kind === 'any' ? 1 : 2);
+                            var rb = (b.kind === wanted) ? 0 : (b.kind === 'any' ? 1 : 2);
+                            return ra - rb;
+                        });
+                        fns.forEach(function(f) {
+                            valueProperty.append($("<option></option>").val(f.v).text(f.t));
+                        });
+                    })();
+                    valueProperty.val(window.hal2GroupAggregate.isFunction(group.aggregate) ? group.aggregate : '');
+
+                    var syncValueRow = function() {
+                        if (stateMembers === 0) {
+                            valueProperty.val('').prop('disabled', true);
+                            rowValueTip.text('No members with a state — a command-only group has nothing to aggregate.');
+                            return;
+                        }
+                        valueProperty.prop('disabled', false);
+                        if (!valueProperty.val()) {
+                            rowValueTip.text('Without a value the group can only be commanded, not read or watched.');
+                        } else {
+                            rowValueTip.text('Computed from ' + stateMembers + ' member' + (stateMembers === 1 ? '' : 's') +
+                                ' with a state; members whose thing is offline are left out.');
+                        }
+                    };
+                    valueProperty.change(syncValueRow);
+                    syncValueRow();
 
                     var rateProperty = $('<input/>', { style: "width:80px", type: "number", min: "0", class: "node-config-eh-group-ratelimit-property" })
                         .appendTo(rowRate).val(typeof group.ratelimit === 'undefined' ? 0 : group.ratelimit);
@@ -697,6 +776,7 @@
                         id:        item.find(".node-config-eh-group-id-property").val(),
                         name:      name,
                         haType:    item.find(".node-config-eh-group-hatype-property").val(),
+                        aggregate: item.find(".node-config-eh-group-aggregate-property").val() || '',
                         ratelimit: Number(item.find(".node-config-eh-group-ratelimit-property").val()) || 0,
                         notes:     item.find(".node-config-eh-group-notes-property").val() || ''
                     });

--- a/core/eventhandler.html
+++ b/core/eventhandler.html
@@ -391,7 +391,7 @@
                     var rowDetails = $('<div/>', { style: "margin-top:8px;" }).appendTo(container).hide();
                     var rowType    = $('<div/>', { style: "margin-top:8px;" }).appendTo(rowDetails);
                     var rowValue   = $('<div/>', { style: "margin-top:8px;" }).appendTo(rowDetails);
-                    var rowValueTip= $('<div/>', { style: "margin-top:4px; margin-left:115px; color:#888; font-size:12px;" }).appendTo(rowDetails);
+                    var rowValueTip= $('<div/>', { style: "margin-top:4px; margin-left:115px; margin-right:10px; color:#888; font-size:12px; white-space:normal; line-height:1.4;" }).appendTo(rowDetails);
                     var rowRate    = $('<div/>', { style: "margin-top:8px;" }).appendTo(rowDetails);
                     var rowNotes   = $('<div/>', { style: "margin-top:8px;" }).appendTo(rowDetails);
 
@@ -493,7 +493,7 @@
                         message += '<br><b>Value</b><br>';
                         message += fnNow
                             ? window.hal2GroupAggregate.label(fnNow) +
-                              '<br>Readable by Value, Gate, Event and Bayes nodes.<br>'
+                              '<br>Readable by Value, Gate, Event and Bayes nodes. Offline members are left out.<br>'
                             : 'No value — this group can be commanded but not read.<br>';
 
                         message += '<br><b>Used in</b>';
@@ -551,9 +551,10 @@
                     });
                     haTypeProperty.val(currentHaType);
 
-                    // How many members carry state. A command-only group has nothing to
-                    // aggregate, so the field is offered but disabled rather than hidden —
-                    // the empty select would otherwise look like a bug.
+                    // How many members currently carry state. Only ever reported, never used
+                    // to gate the field: a group is created before anything joins it, so
+                    // disabling the choice until it has members would make it unreachable at
+                    // exactly the moment you want to set it.
                     var stateMembers = (function() {
                         var n = 0;
                         var gid = idProperty.val();
@@ -595,17 +596,13 @@
                     valueProperty.val(window.hal2GroupAggregate.isFunction(group.aggregate) ? group.aggregate : '');
 
                     var syncValueRow = function() {
-                        if (stateMembers === 0) {
-                            valueProperty.val('').prop('disabled', true);
-                            rowValueTip.text('No members with a state — a command-only group has nothing to aggregate.');
-                            return;
-                        }
-                        valueProperty.prop('disabled', false);
                         if (!valueProperty.val()) {
                             rowValueTip.text('Without a value the group can only be commanded, not read or watched.');
+                        } else if (stateMembers === 0) {
+                            rowValueTip.text('No members with a state yet — add some from the Thing editor.');
                         } else {
                             rowValueTip.text('Computed from ' + stateMembers + ' member' + (stateMembers === 1 ? '' : 's') +
-                                ' with a state; members whose thing is offline are left out.');
+                                ' with a state. Offline members are left out.');
                         }
                     };
                     valueProperty.change(syncValueRow);

--- a/core/eventhandler.js
+++ b/core/eventhandler.js
@@ -11,6 +11,7 @@ const {
     TOOL_HARDWARE_REQUIREMENTS, expandHaTypeFilter, deriveCategories
 } = require('./mcp-tools');
 const { createToolGate, claimAllows } = require('../lib/claim-gate');
+const groupAggregate = require('../resources/group-aggregate');
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
@@ -307,11 +308,15 @@ module.exports = function(RED) {
 
         // ── Group engine ────────────────────────────────────────────────────────
         // Groups are no longer separate nodes. Their identity (name, haType, notes,
-        // ratelimit) lives here on the EventHandler; membership lives per item on each
-        // hal2Thing (thing.groups = [{item, group}]). This engine resolves membership
-        // and wires, per group: a command listener that broadcasts to members, and
-        // update listeners that re-emit member changes under the group id (carrying the
-        // real member thing/item so event nodes get member context).
+        // ratelimit, aggregate) lives here on the EventHandler; membership lives per item
+        // on each hal2Thing (thing.groups = [{item, group}]). This engine resolves
+        // membership and wires, per group: a command listener that broadcasts to members,
+        // and update listeners that maintain the group's own value and emit it.
+        //
+        // A group with an `aggregate` function has a state of its own, computed from its
+        // members and shaped exactly like a hal2Thing item's — state/laststate, its own
+        // last_update/last_change — so hal2Event, hal2Value, hal2Gate and hal2Bayes can
+        // read a group wherever they can read a thing.
         //
         // Back-compat: legacy hal2Group nodes are folded in automatically (in memory)
         // by reading their config — old flows keep working with no file changes and no
@@ -320,24 +325,53 @@ module.exports = function(RED) {
         // Action/Event references keep pointing at the same id either way.
 
         node.groupWirings = [];
-
-        function commandCapableItem(item) {
-            const t = item && item.type;
-            return (t === 'both' || t === 'command' || t === 'loopback_both' || t === 'loopback_command');
+        // groupId -> { state, laststate, last_update, last_change, members, live, fn, name }
+        // Restored so laststate and last_change survive a restart, the same way a thing
+        // persists its own (core/thing.js:52-55). The values themselves are recomputed from
+        // live members at startup regardless.
+        const groupContext = node.context();
+        node.groupState = groupContext.get('groupState', node.contextStore) || {};
+        function persistGroupState() {
+            groupContext.set('groupState', node.groupState, node.contextStore);
         }
 
-        // groupId -> { ratelimit, legacy } merged from the registry and any legacy
-        // hal2Group nodes belonging to this handler. The registry wins on collision
-        // (i.e. once a group has been migrated, its hal2Group node is ignored).
+        const commandCapableItem = common.commandCapableItem;
+        const statusCapableItem  = common.statusCapableItem;
+
+        // The reserved heartbeat item. It is never aggregated, but a change to it flips a
+        // member in or out of every group it belongs to, so it has to trigger a recompute.
+        const HEARTBEAT_ITEM = '1';
+
+        // Read by hal2Value / hal2Gate / hal2Bayes. Returns undefined for an unknown group
+        // or one with no value configured, which reads as "nothing to compare" everywhere.
+        node.getGroupState = function (groupId) {
+            return node.groupState[groupId];
+        };
+
+        // groupId -> { ratelimit, aggregate, name, legacy } merged from the registry and any
+        // legacy hal2Group nodes belonging to this handler. The registry wins on collision
+        // (i.e. once a group has been migrated, its hal2Group node is ignored). Legacy nodes
+        // never carry an aggregate — the field only exists in the registry.
         function buildGroupDefs() {
             const defs = new Map();
             for (const g of node.groups) {
-                if (g && g.id) defs.set(g.id, { ratelimit: Number(g.ratelimit) || 0, legacy: false });
+                if (!g || !g.id) continue;
+                defs.set(g.id, {
+                    ratelimit: Number(g.ratelimit) || 0,
+                    aggregate: groupAggregate.isFunction(g.aggregate) ? g.aggregate : null,
+                    name: g.name || g.id,
+                    legacy: false
+                });
             }
             RED.nodes.eachNode(function (cfg) {
                 if (cfg.type !== 'hal2Group' || cfg.eventHandler !== node.id) return;
                 if (defs.has(cfg.id)) return;
-                defs.set(cfg.id, { ratelimit: Number(cfg.ratelimit) || 0, legacy: true });
+                defs.set(cfg.id, {
+                    ratelimit: Number(cfg.ratelimit) || 0,
+                    aggregate: null,
+                    name: cfg.name || cfg.id,
+                    legacy: true
+                });
             });
             return defs;
         }
@@ -379,10 +413,83 @@ module.exports = function(RED) {
             node.groupWirings = [];
         }
 
+        // Collect the samples a group's value is computed from. A member contributes only if
+        // its thing resolves, its item carries state, and the thing is alive — a device that
+        // has dropped off the network must not keep voting with the value it had before it
+        // went quiet. Members with no state yet are passed through as undefined and dropped
+        // by the aggregation, so "nobody reporting" and "no members" are one case.
+        function groupSamples(groupMembers) {
+            const samples = [];
+            let eligible = 0;
+            for (const m of groupMembers) {
+                const thing = RED.nodes.getNode(m.thing);
+                if (!thing || !thing.thingType || !Array.isArray(thing.thingType.items)) continue;
+                const item = thing.thingType.items.find(it => it.id === m.item);
+                if (!item || !statusCapableItem(item)) continue;
+                if (m.item === HEARTBEAT_ITEM) continue;   // liveness is a filter, not a value
+                eligible += 1;
+                if (!common.isThingAlive(thing)) continue;
+                samples.push({
+                    state: thing.state ? thing.state[m.item] : undefined,
+                    updatedAt: (thing.heartbeat && thing.heartbeat[m.item]) || 0
+                });
+            }
+            return { samples, eligible };
+        }
+
+        // Recompute one group's value and, unless we are priming at startup, announce it.
+        // The record mirrors a thing item's: laststate and last_change only move when the
+        // value actually changed, so hal2Event's change filters behave identically whether
+        // they watch a thing or a group (core/thing.js:218-231).
+        function recomputeGroup(groupId, def, groupMembers, trigger) {
+            const { samples, eligible } = groupSamples(groupMembers);
+            const value = groupAggregate.aggregate(def.aggregate, samples);
+            const now   = Date.now();
+            const prev  = node.groupState[groupId] || {};
+            const changed = prev.state !== value;
+
+            const rec = {
+                state:       value,
+                laststate:   changed ? prev.state : prev.laststate,
+                last_update: now,
+                last_change: changed ? now : (prev.last_change || now),
+                members:     eligible,
+                live:        samples.length,
+                fn:          def.aggregate,
+                name:        def.name
+            };
+            node.groupState[groupId] = rec;
+            persistGroupState();
+
+            if (!trigger) { return rec; }   // startup priming stays silent
+
+            const eventmsg = {
+                _msgid:    RED.util.generateId(),
+                state:     rec.state,
+                laststate: rec.laststate,
+                payload:   rec.state,
+                topic:     '',
+                group: {
+                    id: groupId, name: def.name, function: def.aggregate,
+                    members: rec.members, live: rec.live,
+                    last_update: rec.last_update, last_change: rec.last_change
+                },
+                // Which member moved the group. Kept because "the hall light is what turned
+                // the group on" is exactly the context an event flow wants next.
+                member: trigger
+            };
+            node.debug('Group ' + def.name + ' (' + def.aggregate + ') = ' + JSON.stringify(rec.state));
+            // Emitted straight onto the bus rather than through publishUpdate: a group's
+            // value is derived, so it must not be written to the history database.
+            node.emit('update_' + groupId, null, groupId, groupId, eventmsg);
+            return rec;
+        }
+
         function wireGroups() {
             unwireGroups();   // idempotent — safe to re-run on every flows:started
             const members = buildGroupMembers();
             const defs    = buildGroupDefs();
+            const valueGroups = [];
             let legacyCount = 0;
             for (const [groupId, def] of defs) {
                 const groupMembers = members.get(groupId) || [];
@@ -409,20 +516,44 @@ module.exports = function(RED) {
                 node.subscribe('command', groupId, commandListener);
                 node.groupWirings.push({ event: 'command', id: groupId, listener: commandListener, throttle: throttle });
 
-                // Update: re-emit member changes under the group id, keeping the real
-                // member thing/item so event nodes can show which member changed.
+                // Update: maintain the group's own value and emit it. A group without an
+                // aggregation is command-only and has nothing to observe; the sweep below
+                // clears any record it used to have.
+                if (!def.aggregate) { continue; }
+
                 const updateListener = function (thingtypeid, thingid, itemid, payload) {
                     const isMember = groupMembers.some(m => m.thing === thingid && m.item === itemid);
-                    if (!isMember) return;
-                    node.emit('update_' + groupId, thingtypeid, thingid, itemid, payload);
+                    // A heartbeat is not a member item, but it decides whether that thing's
+                    // members count at all — so it has to recompute too, or a group would keep
+                    // counting a device for as long as it stayed silent.
+                    if (!isMember && itemid !== HEARTBEAT_ITEM) return;
+                    const trigger = {
+                        thing: { id: thingid, name: (payload && payload.thing && payload.thing.name) || thingid },
+                        item:  { id: itemid,  name: (payload && payload.item  && payload.item.name)  || itemid },
+                        heartbeat: !isMember
+                    };
+                    recomputeGroup(groupId, def, groupMembers, trigger);
                 };
                 const uniqueThings = [...new Set(groupMembers.map(m => m.thing))];
                 for (const t of uniqueThings) {
                     node.subscribe('update', t, updateListener);
                     node.groupWirings.push({ event: 'update', id: t, listener: updateListener });
                 }
+
+                // Prime the value so the group can be read before any member moves.
+                recomputeGroup(groupId, def, groupMembers, null);
+                valueGroups.push(def.name + ' (' + def.aggregate + ')');
             }
+            // Drop records for groups that no longer exist or lost their aggregation, so a
+            // stale value cannot be read from a deleted group after a redeploy.
+            for (const id of Object.keys(node.groupState)) {
+                if (!defs.has(id) || !defs.get(id).aggregate) { delete node.groupState[id]; }
+            }
+            persistGroupState();
             node.debug('Group engine wired ' + defs.size + ' group(s)');
+            if (valueGroups.length) {
+                node.log('Group values: ' + valueGroups.join(', '));
+            }
             if (legacyCount > 0) {
                 node.warn('Group engine: auto-handling ' + legacyCount + ' legacy hal2Group node(s) in memory. ' +
                     'Run tools/migrate-groups.js to make this permanent and remove the deprecated nodes.');
@@ -627,7 +758,7 @@ module.exports = function(RED) {
                         thing_name  : thing.name,
                         type_id     : tt.id,
                         type_name   : tt.name,
-                        alive       : tt.hbCheck === false ? true : thing.state['1'] !== false,
+                        alive       : common.isThingAlive(thing),
                         last_change : msToIso(lastChange[thing.id]),
                         items
                     };

--- a/core/eventhandler.js
+++ b/core/eventhandler.js
@@ -444,20 +444,15 @@ module.exports = function(RED) {
         function recomputeGroup(groupId, def, groupMembers, trigger) {
             const { samples, eligible } = groupSamples(groupMembers);
             const value = groupAggregate.aggregate(def.aggregate, samples);
-            const now   = Date.now();
-            const prev  = node.groupState[groupId] || {};
-            const changed = prev.state !== value;
+            const step  = groupAggregate.nextRecord(node.groupState[groupId], value, Date.now());
 
-            const rec = {
-                state:       value,
-                laststate:   changed ? prev.state : prev.laststate,
-                last_update: now,
-                last_change: changed ? now : (prev.last_change || now),
-                members:     eligible,
-                live:        samples.length,
-                fn:          def.aggregate,
-                name:        def.name
-            };
+            const rec = Object.assign({}, step, {
+                members: eligible,
+                live:    samples.length,
+                fn:      def.aggregate,
+                name:    def.name
+            });
+            delete rec.changed;          // a transient of the step, not part of the record
             node.groupState[groupId] = rec;
             persistGroupState();
 

--- a/core/gate.html
+++ b/core/gate.html
@@ -9,7 +9,7 @@
         <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
         <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
     </div>
-    <div class="form-tips" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
+    <div class="form-tips" style="margin-left:105px; width:calc(100% - 170px); max-width:none; box-sizing:border-box; margin-bottom:8px;">
         <small>Only needed when a rule reads a <b>Group</b> &mdash; pick the Event handler that owns it.</small>
     </div>
     <div class="form-row">
@@ -120,8 +120,12 @@
                         .appendTo(container)
                         .hide()
                     var rowRule = $('<div/>',{style:"margin-top:8px;"}).appendTo(container);
+                    // The label column is 80px (border-box, padding included) and the fields
+                    // are calc(100% - 110px), so this lines the tip up with them exactly.
+                    // max-width has to go: form-tips caps itself at 450px, which is what pulled
+                    // the right edge in short of the field above.
                     var rowGroupTip = $('<div/>', { class: "form-tips",
-                        style: "margin-top:8px; margin-left:90px; width:calc(100% - 110px); box-sizing:border-box; white-space:normal;" })
+                        style: "margin-top:8px; margin-left:80px; width:calc(100% - 110px); max-width:none; box-sizing:border-box; white-space:normal;" })
                         .appendTo(container).hide();
 
                     //Add labels

--- a/core/gate.html
+++ b/core/gate.html
@@ -120,6 +120,9 @@
                         .appendTo(container)
                         .hide()
                     var rowRule = $('<div/>',{style:"margin-top:8px;"}).appendTo(container);
+                    var rowGroupTip = $('<div/>', { class: "form-tips",
+                        style: "margin-top:8px; margin-left:90px; width:calc(100% - 110px); box-sizing:border-box; white-space:normal;" })
+                        .appendTo(container).hide();
 
                     //Add labels
                     var labelName = $('<div/>',{style:"display:inline-block;text-align:left; width:80px; padding-right:10px; box-sizing:border-box;",class:"fa fa-microchip"})
@@ -166,8 +169,13 @@
                             itemsField.children().remove();
                             itemsField.append($("<option></option>").val(thingsField.val()).text(thingsField.val()));
                             itemsField.val(thingsField.val());
+                            var g = groupsList.filter(function(x) { return x.id === thingsField.val(); })[0];
+                            rowGroupTip.html($('<small/>').text(g
+                                ? 'Value: ' + window.hal2GroupAggregate.label(g.aggregate) : ''));
+                            rowGroupTip.toggle(!!g);
                             return;
                         }
+                        rowGroupTip.hide();
                         rowItem.show();
                         if (thingsField.val() == 'dynamic') {
                             rowTypes.show();
@@ -355,10 +363,11 @@
                             } else {
                                 console.error('ThingType ID '+rule.thingtype+' is missing.');
                             }
-                            $("#node-input-rule-container").editableList('addItem',rule);
                         } catch (error) {
                             console.log('Error: '+error.message);
                         }
+                    } else if (groupIds[rule.thing]) {
+                        $("#node-input-rule-container").editableList('addItem',rule);
                     } else {
                         try {
                             let thing = RED.nodes.node(rule.thing);

--- a/core/gate.html
+++ b/core/gate.html
@@ -6,6 +6,10 @@
         <input type="text" id="node-input-name" placeholder="Name" style="width:calc(100% - 170px)">
     </div>
     <div class="form-row">
+        <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
+        <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
+    </div>
+    <div class="form-row">
         <ol id="node-input-rule-container"</ol>
     </div>
     <div class="form-row">
@@ -24,7 +28,9 @@
 <script type="text/x-red" data-help-name="hal2Gate">
     <p>The Gate node is used to redirect the flow depending on if certain <i>Item</i> conditions are met.</p>
     <li><strong>Name</strong>: Node name.</li> 
-    <li><strong>Rules</strong>: Add one or more conditions to be met.</li>
+    <li><strong>Event handler</strong>: Only needed when a rule reads a <i>Group</i>; it is where group values live.</li>
+    <li><strong>Rules</strong>: Add one or more conditions to be met. A rule's source can be a Thing, a Thing set by <code>msg.thing.id</code>, or a <i>Group</i> that has been given a <b>Value</b> on the Event handler's Groups tab. A group carries one aggregated value, so it needs no Item.</li>
+    <li><strong>No value</strong>: A rule whose source cannot be read — a missing Thing, or a group where no live member is reporting — does not match, rather than comparing against a stale or invented value.</li>
     <li><strong>TSU</strong>: Time since last update (in seconds)</li>
     <li><strong>TSC</strong>: Time since last change (in seconds)</li>
     <li><strong>Set <code>msg.payload</code> to result</strong>: Sends true or false.</li>
@@ -36,6 +42,9 @@
         color: '#b3b3ff',
         defaults: {
             name:       {},
+            // Optional: only a Group rule needs it, and requiring it would flag every
+            // existing Gate node as invalid.
+            eventHandler: { value: "", type: "hal2EventHandler", required: false },
             rules:      {},
             checkall:   { value: "true" },
             if:         {},
@@ -58,8 +67,13 @@
             ]);
 
             var thingsList = halGetThings(RED,'status');
+            var groupsList = halGetGroups(RED, $("#node-input-eventHandler").val(), 'value');
+            // Membership test for the rule rows: a group id is not a node, so this is the
+            // only way to tell the two kinds of entry in the source select apart.
+            var groupIds = {};
+            for (var gi in groupsList) { groupIds[groupsList[gi].id] = true; }
             //No thing nodes have been created
-            if(thingsList.length===0){
+            if(thingsList.length===0 && groupsList.length===0){
                 $("<li>No things found</li>").appendTo("#node-input-rule-container");
                 return;
             }
@@ -127,9 +141,22 @@
                     var itemsField = $('<select/>',{class:"node-input-rule-item",style:"width:calc(100% - 110px)"}).appendTo(rowItem);
                     var itemNotesField = $('<textarea/>',{style:"width:calc(100% - 110px);background-color:#ffe;"}).appendTo(rowItemNotes);
 
+                    var isGroupRule = function() { return groupIds[thingsField.val()] === true; };
+
                     thingsField.change(function() {
                         var thing;
                         var thingType;
+                        // A group has one value and no items, so the item row is what the
+                        // group id goes into — the same place a thing's item id would.
+                        if (isGroupRule()) {
+                            rowTypes.hide(); rowNotes.hide(); rowItem.hide(); rowItemNotes.hide();
+                            rowFilter.hide(); thingsFilter.hide();
+                            itemsField.children().remove();
+                            itemsField.append($("<option></option>").val(thingsField.val()).text(thingsField.val()));
+                            itemsField.val(thingsField.val());
+                            return;
+                        }
+                        rowItem.show();
                         if (thingsField.val() == 'dynamic') {
                             rowTypes.show();
                             rowNotes.hide();
@@ -201,6 +228,7 @@
 
                     itemsField.change(function() {
                         rowItemNotes.hide();
+                        if (isGroupRule()) { return; }
                         var thing = RED.nodes.node(thingsField.val());
                         var thingType = RED.nodes.node(thing.thingType);
                         var item = itemsField.val();
@@ -217,10 +245,15 @@
 
                     //Add things
                     thingsField.append($("<option></option>").val('dynamic').text('Thing - set by msg.thing.id -'));
+                    // Groups sit in the same select as things: a rule reads one value either
+                    // way, and the source list stays one list.
+                    for (var d in groupsList) {
+                        thingsField.append($("<option></option>").val(groupsList[d].id).text('Group - ' + groupsList[d].name));
+                    }
                     for (var d in thingsList) {
                         thingsField.append($("<option></option>").val(thingsList[d].id).text(thingsList[d].name));
                     }
-                    thingsField.val(thingsList[0].id);
+                    thingsField.val(thingsList.length ? thingsList[0].id : 'dynamic');
                     
 
                     //Add thingTypes
@@ -332,6 +365,9 @@
             }            
         },
         oneditsave: function() {
+            var savedGroups = {};
+            halGetGroups(RED, $("#node-input-eventHandler").val(), 'value')
+                .forEach(function(g) { savedGroups[g.id] = true; });
             var rules = $("#node-input-rule-container").children();
             var ruleset;
             var node = this;
@@ -347,6 +383,7 @@
                 var type  = rule.find(".node-input-rule-value").typedInput('type');
 
                 var r = {thing:thing, thingtype:thingtype, item:item, operator:operator, value:value, type:type};
+                if (savedGroups[thing]) { r.category = 'hal2Group'; }
                 node.rules.push(r);
             });
 

--- a/core/gate.html
+++ b/core/gate.html
@@ -10,8 +10,7 @@
         <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
     </div>
     <div class="form-tips" style="margin-left:105px; margin-bottom:8px;">
-        <small>Only needed when a rule reads a <b>Group</b>. A Thing points at its own Event handler,
-        but a group is not a node &mdash; its value lives in the handler's group registry.</small>
+        <small>Only needed when a rule reads a <b>Group</b> &mdash; pick the Event handler that owns it.</small>
     </div>
     <div class="form-row">
         <ol id="node-input-rule-container"</ol>

--- a/core/gate.html
+++ b/core/gate.html
@@ -9,7 +9,7 @@
         <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
         <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
     </div>
-    <div class="form-tips" style="margin-left:105px; margin-bottom:8px;">
+    <div class="form-tips" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
         <small>Only needed when a rule reads a <b>Group</b> &mdash; pick the Event handler that owns it.</small>
     </div>
     <div class="form-row">

--- a/core/gate.html
+++ b/core/gate.html
@@ -9,6 +9,10 @@
         <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
         <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
     </div>
+    <div class="form-tips" style="margin-left:105px; margin-bottom:8px;">
+        <small>Only needed when a rule reads a <b>Group</b>. A Thing points at its own Event handler,
+        but a group is not a node &mdash; its value lives in the handler's group registry.</small>
+    </div>
     <div class="form-row">
         <ol id="node-input-rule-container"</ol>
     </div>
@@ -44,7 +48,16 @@
             name:       {},
             // Optional: only a Group rule needs it, and requiring it would flag every
             // existing Gate node as invalid.
-            eventHandler: { value: "", type: "hal2EventHandler", required: false },
+            eventHandler: {
+                value: "", type: "hal2EventHandler", required: false,
+                // Needed only once a rule reads a group. Rules are harvested on save, so this
+                // judges the saved ruleset — a group rule added and left without a handler is
+                // flagged as soon as the dialog closes.
+                validate: function (v) {
+                    var needed = (this.rules || []).some(function (r) { return r && r.category === 'hal2Group'; });
+                    return !needed || (!!v && v !== '_ADD_');
+                }
+            },
             rules:      {},
             checkall:   { value: "true" },
             if:         {},

--- a/core/gate.html
+++ b/core/gate.html
@@ -106,6 +106,13 @@
 
                     //Add rows
                     var rowName = $('<div/>').appendTo(container);
+                    // Directly under the source select, as in the other nodes. The label column
+                    // is 80px (border-box, padding included) and the fields are
+                    // calc(100% - 110px), so this lines up with them exactly; max-width has to
+                    // go because form-tips caps itself at 450px.
+                    var rowGroupTip = $('<div/>', { class: "form-tips",
+                        style: "margin-top:8px; margin-left:80px; width:calc(100% - 110px); max-width:none; box-sizing:border-box; white-space:normal;" })
+                        .appendTo(container).hide();
                     var rowTypes = $('<div/>',{style:"margin-top:8px;"})
                         .appendTo(container)
                         .hide()  
@@ -120,13 +127,6 @@
                         .appendTo(container)
                         .hide()
                     var rowRule = $('<div/>',{style:"margin-top:8px;"}).appendTo(container);
-                    // The label column is 80px (border-box, padding included) and the fields
-                    // are calc(100% - 110px), so this lines the tip up with them exactly.
-                    // max-width has to go: form-tips caps itself at 450px, which is what pulled
-                    // the right edge in short of the field above.
-                    var rowGroupTip = $('<div/>', { class: "form-tips",
-                        style: "margin-top:8px; margin-left:80px; width:calc(100% - 110px); max-width:none; box-sizing:border-box; white-space:normal;" })
-                        .appendTo(container).hide();
 
                     //Add labels
                     var labelName = $('<div/>',{style:"display:inline-block;text-align:left; width:80px; padding-right:10px; box-sizing:border-box;",class:"fa fa-microchip"})

--- a/core/gate.js
+++ b/core/gate.js
@@ -15,50 +15,65 @@ module.exports = function(RED) {
         //a=state, b=comparison value
         var compare = rules.COMPARE;
 
-        var ruleMatch = 0;
-        for (var i = 0; i < node.rules.length; i += 1) {
-            var rule = node.rules[i];
-            var id;
-            if (rule.thing == 'dynamic') {
-                id = common.thingIdFromMsg(RED,node,rule.thingtype,msg);
-                if (typeof id == 'undefined') { continue; }
-            } else {
-                id = rule.thing;
+        // The state a rule compares against, plus the timestamps the last_* operators need.
+        // A thing keeps these per item; a group keeps one set for its whole aggregated value.
+        function sourceOf(rule) {
+            if (rule.category === 'hal2Group') {
+                if (!node.eventHandler || typeof node.eventHandler.getGroupState !== 'function') {
+                    node.warn('Rule skipped: a group rule needs an event handler on this node');
+                    return null;
+                }
+                var rec = node.eventHandler.getGroupState(rule.thing);
+                // No record, or no live member reporting: the rule has nothing to compare
+                // and does not match, rather than matching against a stale or invented value.
+                if (!rec || rec.state === undefined) { return null; }
+                return { state: rec.state, laststate: rec.laststate,
+                         last_update: rec.last_update, last_change: rec.last_change };
             }
-
+            var id = (rule.thing == 'dynamic')
+                ? common.thingIdFromMsg(RED,node,rule.thingtype,msg)
+                : rule.thing;
+            if (typeof id == 'undefined') { return null; }
             var thing;
             try {
                 thing = RED.nodes.getNode(id);
             } catch (error) {
                 console.log('Error: '+error.message);
             }
-            if ( typeof thing == 'undefined' ) { continue; }
+            if (typeof thing == 'undefined' || thing === null) { return null; }
+            if (!thing.state || !thing.state.hasOwnProperty(rule.item)) { return null; }
+            return { state: thing.state[rule.item], laststate: thing.laststate[rule.item],
+                     last_update: thing.heartbeat[rule.item], last_change: thing.last_change[rule.item] };
+        }
+
+        var ruleMatch = 0;
+        for (var i = 0; i < node.rules.length; i += 1) {
+            var rule = node.rules[i];
+            var src = sourceOf(rule);
+            if (src === null) { continue; }      // unresolvable source never matches
 
             var cv = convertTo[rule.type](rule.value,msg);
 
-            // Check if item has state
-            if (thing.state.hasOwnProperty(rule.item)) {
-                if (rule.operator.includes('last_')) {
-                    let now = Date.now();
-                    let last_update = Math.trunc((now - thing.heartbeat[rule.item])/1000);
-                    let last_change = Math.trunc((now - thing.last_change[rule.item])/1000);
-                    switch (rule.operator) {
-                        case 'last_update_gte':
-                            if (last_update >= Number(cv)) { ruleMatch++; }
-                            break;
-                        case 'last_update_lte':
-                            if (last_update <= Number(cv)) { ruleMatch++; }
-                            break;
-                        case 'last_change_gte':
-                            if (last_change >= Number(cv)) { ruleMatch++; }
-                            break;
-                        case 'last_change_lte':
-                            if (last_change <= Number(cv)) { ruleMatch++; }
-                            break;
-                    }
-                } else if (compare[rule.operator](thing.state[rule.item],cv,thing.laststate[rule.item])){
-                    ruleMatch ++;
+            if (rule.operator.includes('last_')) {
+                let now = Date.now();
+                let last_update = Math.trunc((now - src.last_update)/1000);
+                let last_change = Math.trunc((now - src.last_change)/1000);
+                switch (rule.operator) {
+                    case 'last_update_gte':
+                        if (last_update >= Number(cv)) { ruleMatch++; }
+                        break;
+                    case 'last_update_lte':
+                        if (last_update <= Number(cv)) { ruleMatch++; }
+                        break;
+                    case 'last_change_gte':
+                        if (last_change >= Number(cv)) { ruleMatch++; }
+                        break;
+                    case 'last_change_lte':
+                        if (last_change <= Number(cv)) { ruleMatch++; }
+                        break;
                 }
+            } else if (compare[rule.operator](src.state,cv,src.laststate)){
+                ruleMatch ++;
             }
         }
 
@@ -84,6 +99,7 @@ module.exports = function(RED) {
     function hal2Gate(config) {
         RED.nodes.createNode(this,config);
         this.name = config.name;
+        this.eventHandler = RED.nodes.getNode(config.eventHandler);
         this.rules = config.rules;
         this.checkall = config.checkall;
         this.if = config.if;

--- a/core/value.html
+++ b/core/value.html
@@ -221,6 +221,9 @@
                     $("#div-type").hide();
                     $("#node-input-action").val('get');
                     $("#node-input-thing").children().remove();
+                    if (groupsList.length === 0) {
+                        $("<option value=''>- no groups with a value -</option>").appendTo("#node-input-thing");
+                    }
                     for (var d in groupsList) {
                         $("<option value='" + groupsList[d].id + "'>" + groupsList[d].name + "</option>")
                             .appendTo("#node-input-thing");
@@ -234,7 +237,12 @@
                     $("#thing-filter-button").show();
                     $("#node-input-thing").children().remove();
                     $("#thing-filter").trigger('change');
-                    if (savedTypeSel !== 'hal2Group') { $("#node-input-thing").val(savedThing); }
+                    if (savedTypeSel !== 'hal2Group' && savedThing) {
+                        $("#node-input-thing").val(savedThing);
+                    }
+                    if ($("#node-input-thing").val() === null && thingsList.length) {
+                        $("#node-input-thing").val(thingsList[0].id);
+                    }
                 }
                 $("#node-input-action").prop('disabled', group);
                 $("#node-input-thing").trigger('change');
@@ -298,7 +306,9 @@
 
                 //get all items and sort them alphabetically
                 let thing = RED.nodes.node($("#node-input-thing").val());
+                if (!thing) { $("#row-notes").hide(); return; }
                 let thingType = RED.nodes.node(thing.thingType);
+                if (!thingType) { $("#row-notes").hide(); return; }
                 // Show notes
                 if (thing.notes) {
                     $("#row-notes").show();
@@ -392,8 +402,9 @@
                     var thingType = RED.nodes.node($("#node-input-thingType").val());
                 } else {
                     var thing = RED.nodes.node($("#node-input-thing").val());
-                    var thingType = RED.nodes.node(thing.thingType);
+                    var thingType = thing ? RED.nodes.node(thing.thingType) : null;
                 }
+                if (!thingType || !thingType.items) { updateHistoryVisibility(); return; }
                 var item = $("#node-input-item").val();
                 for (let d in thingType.items) {
                     if (thingType.items[d].id == item) {

--- a/core/value.html
+++ b/core/value.html
@@ -16,7 +16,7 @@
             <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
             <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
         </div>
-        <div class="form-tips" id="row-eh-tip" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
+        <div class="form-tips" id="row-eh-tip" style="margin-left:105px; width:calc(100% - 170px); max-width:none; box-sizing:border-box; margin-bottom:8px;">
             <small>Pick the Event handler that owns the group.</small>
         </div>
         <div class="form-row">
@@ -31,7 +31,7 @@
             <select id="node-input-thing" style="width:calc(100% - 170px)"></select>
             <button id="thing-filter-button"><i class="fa fa-filter"></i></button>
         </div>
-        <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
+        <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); max-width:none; box-sizing:border-box; margin-bottom:8px;">
             <small id="group-tip"></small>
         </div>
         <div class="form-row" id="thing-filter-div" hidden>

--- a/core/value.html
+++ b/core/value.html
@@ -5,16 +5,20 @@
         <p>No items found. Start by creating some Things.</p>
     </div>
     <div class="form-row" id="div-main">
-        <div class="form-row" id="row-event-handler">
-            <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
-            <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
-        </div>
         <div class="form-row">
             <label for="node-input-typeSel" style="width:95px; padding-right:10px;"><i class="fa fa-folder"></i> Category</label>
             <select id="node-input-typeSel" style="width:calc(100% - 170px)">
                 <option value='hal2Thing'>Thing</option>
                 <option value='hal2Group'>Group</option>
             </select>
+        </div>
+        <div class="form-row" id="row-event-handler">
+            <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
+            <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
+        </div>
+        <div class="form-tips" id="row-eh-tip" style="margin-left:105px; margin-bottom:8px;">
+            <small>A Thing points at its own Event handler, but a group is not a node &mdash; its value
+            lives in the handler's group registry, so this node has to be told which handler owns it.</small>
         </div>
         <div class="form-row">
             <label for="node-input-action" style="width:95px; padding-right:10px;"><i class="fa fa-exchange"></i> Action</label>
@@ -23,9 +27,8 @@
                 <option value='set'>Set value</option>
             </select>
         </div>
-        <div class="form-row" id="row-group-tip" style="width:100%">
-            <label style="width:95px; padding-right:10px;">&nbsp;</label>
-            <span id="group-tip" style="color:#888; font-size:12px;"></span>
+        <div class="form-tips" id="row-group-tip" style="margin-left:105px; margin-bottom:8px;">
+            <small id="group-tip"></small>
         </div>
         <div class="form-row" id="row-thing">
             <label for="node-input-thing" id="label-node-input-thing" style="width:95px; padding-right:10px;" class="fa fa-microchip"> Thing</label>
@@ -123,7 +126,8 @@
 
 <script type="text/x-red" data-help-name="hal2Value">
     <p>The Value node is used to either query a specific <i>Item</i> and send the <i>Item</i> value on to the next node, or to update an <i>Item</i> value. In the latter case the ingress function as well as all topic filters are bypassed, the value is updated directly as is. Events are triggered as usual.</p>
-    <li><strong>Category</strong>: Read a single <i>Thing</i>'s Item, or a <i>Group</i>'s own value. A group's value is computed from its members by the Event handler — average, any true, count true and so on — so it is <b>read-only</b>: use an Action node to command a group. Only groups that have been given a <b>Value</b> on the Event handler's Groups tab can be selected, and reading one needs that Event handler set on this node.</li>
+    <li><strong>Category</strong>: Read a single <i>Thing</i>'s Item, or a <i>Group</i>'s own value. A group's value is computed from its members by the Event handler — average, any true, count true and so on — so it is <b>read-only</b>: use an Action node to command a group. Only groups that have been given a <b>Value</b> on the Event handler's Groups tab can be selected.</li>
+    <li><strong>Event handler</strong>: Shown for a <i>Group</i> only. A Thing carries a reference to its own handler, so this node can reach the bus through it; a group is not a node, and its value lives in the handler's group registry — so the handler that owns the group has to be named here.</li>
     <li><strong>Action</strong>: Get value from <i>Item</i> or set value to <i>Item</i>.</li>
     <li><strong>Item</strong>: Select the <i>Item</i>.</li>
     <li><strong>Property</strong>: Source or destination for <i>Item</i> value.</li>
@@ -139,7 +143,22 @@
             name:           {},
             // Optional: only a Group source needs it, and requiring it would flag every
             // existing Value node as invalid.
-            eventHandler:   { value: "", type: "hal2EventHandler", required: false },
+            eventHandler:   {
+                value: "", type: "hal2EventHandler", required: false,
+                // Only a group source needs one, so requiring it outright would flag every
+                // existing Value node. While the dialog is open the live Category wins; on
+                // the canvas (deploy-time validation, no dialog) the saved one does.
+                validate: function (v) {
+                    // #row-eh-tip exists only in this node's template, so it is what tells us
+                    // the open dialog is ours — hal2Event has a #node-input-typeSel too, and
+                    // reading that one would judge this node by another node's form.
+                    var mine  = $("#row-eh-tip").length > 0;
+                    var group = mine ? $("#node-input-typeSel").val() === 'hal2Group'
+                                     : this.typeSel === 'hal2Group';
+                    if (!group) { return true; }
+                    return !!v && v !== '_ADD_';
+                }
+            },
             typeSel:        { value: 'hal2Thing' },
             action:         {},
             // For a Group source `thing` carries the group id and `item` mirrors it, exactly
@@ -212,6 +231,8 @@
             $("#node-input-typeSel").change(function() {
                 var group = isGroup();
                 $("#row-thing").toggle(!group);
+                $("#row-event-handler").toggle(group);
+                $("#row-eh-tip").toggle(group);
                 $("#row-group-tip").toggle(group);
                 $("#div-item").toggle(!group);
                 if (group) {

--- a/core/value.html
+++ b/core/value.html
@@ -16,7 +16,7 @@
             <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
             <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
         </div>
-        <div class="form-tips" id="row-eh-tip" style="margin-left:105px; margin-bottom:8px;">
+        <div class="form-tips" id="row-eh-tip" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
             <small>Pick the Event handler that owns the group.</small>
         </div>
         <div class="form-row">
@@ -26,7 +26,7 @@
                 <option value='set'>Set value</option>
             </select>
         </div>
-        <div class="form-tips" id="row-group-tip" style="margin-left:105px; margin-bottom:8px;">
+        <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
             <small id="group-tip"></small>
         </div>
         <div class="form-row" id="row-thing">

--- a/core/value.html
+++ b/core/value.html
@@ -26,13 +26,13 @@
                 <option value='set'>Set value</option>
             </select>
         </div>
-        <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
-            <small id="group-tip"></small>
-        </div>
         <div class="form-row" id="row-thing">
             <label for="node-input-thing" id="label-node-input-thing" style="width:95px; padding-right:10px;" class="fa fa-microchip"> Thing</label>
             <select id="node-input-thing" style="width:calc(100% - 170px)"></select>
             <button id="thing-filter-button"><i class="fa fa-filter"></i></button>
+        </div>
+        <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); box-sizing:border-box; margin-bottom:8px;">
+            <small id="group-tip"></small>
         </div>
         <div class="form-row" id="thing-filter-div" hidden>
             <label for="thing-filter" id="label-thing-filter" style="width:95px; padding-right:10px;"><i class="fa fa-filter"></i> Filter</label>
@@ -309,9 +309,10 @@
                         $("#node-input-item").val(gid);
                     }
                     var g = groupsList.filter(function(x) { return x.id === gid; })[0];
-                    $("#group-tip").text(g
-                        ? 'Value: ' + window.hal2GroupAggregate.label(g.aggregate)
-                        : '');
+                    // Hidden rather than blank when there is no group to describe — an empty
+                    // tip box reads as something failing to load.
+                    $("#group-tip").text(g ? 'Value: ' + window.hal2GroupAggregate.label(g.aggregate) : '');
+                    $("#row-group-tip").toggle(!!g);
                     return;
                 }
                 if ($("#node-input-thing").val() == '0') {

--- a/core/value.html
+++ b/core/value.html
@@ -17,8 +17,7 @@
             <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
         </div>
         <div class="form-tips" id="row-eh-tip" style="margin-left:105px; margin-bottom:8px;">
-            <small>A Thing points at its own Event handler, but a group is not a node &mdash; its value
-            lives in the handler's group registry, so this node has to be told which handler owns it.</small>
+            <small>Pick the Event handler that owns the group.</small>
         </div>
         <div class="form-row">
             <label for="node-input-action" style="width:95px; padding-right:10px;"><i class="fa fa-exchange"></i> Action</label>
@@ -311,8 +310,7 @@
                     }
                     var g = groupsList.filter(function(x) { return x.id === gid; })[0];
                     $("#group-tip").text(g
-                        ? 'Value: ' + window.hal2GroupAggregate.label(g.aggregate) +
-                          '. Read-only — use an Action node to command a group.'
+                        ? 'Value: ' + window.hal2GroupAggregate.label(g.aggregate)
                         : '');
                     return;
                 }

--- a/core/value.html
+++ b/core/value.html
@@ -5,6 +5,17 @@
         <p>No items found. Start by creating some Things.</p>
     </div>
     <div class="form-row" id="div-main">
+        <div class="form-row" id="row-event-handler">
+            <label for="node-input-eventHandler" style="width:95px; padding-right:10px;"><i class="fa fa-ellipsis-h"></i> Event handler</label>
+            <input type="text" id="node-input-eventHandler" style="width:calc(100% - 170px)" placeholder="Event handler">
+        </div>
+        <div class="form-row">
+            <label for="node-input-typeSel" style="width:95px; padding-right:10px;"><i class="fa fa-folder"></i> Category</label>
+            <select id="node-input-typeSel" style="width:calc(100% - 170px)">
+                <option value='hal2Thing'>Thing</option>
+                <option value='hal2Group'>Group</option>
+            </select>
+        </div>
         <div class="form-row">
             <label for="node-input-action" style="width:95px; padding-right:10px;"><i class="fa fa-exchange"></i> Action</label>
             <select id="node-input-action" style="width:calc(100% - 170px)">
@@ -12,8 +23,12 @@
                 <option value='set'>Set value</option>
             </select>
         </div>
-        <div class="form-row">
-            <label for="node-input-thing" style="width:95px; padding-right:10px;"><i class="fa fa-microchip"></i> Thing</label>
+        <div class="form-row" id="row-group-tip" style="width:100%">
+            <label style="width:95px; padding-right:10px;">&nbsp;</label>
+            <span id="group-tip" style="color:#888; font-size:12px;"></span>
+        </div>
+        <div class="form-row" id="row-thing">
+            <label for="node-input-thing" id="label-node-input-thing" style="width:95px; padding-right:10px;" class="fa fa-microchip"> Thing</label>
             <select id="node-input-thing" style="width:calc(100% - 170px)"></select>
             <button id="thing-filter-button"><i class="fa fa-filter"></i></button>
         </div>
@@ -29,7 +44,7 @@
             <label for="node-input-thingType" style="width:95px; padding-right:10px;"><i class="fa fa-gears"></i> Type</label>
             <select id="node-input-thingType" style="width:calc(100% - 170px)"></select>
         </div>
-        <div class="form-row">
+        <div class="form-row" id="div-item">
             <label for="node-input-item" style="width:95px; padding-right:10px;"><i class="fa fa-sitemap"></i> Item</label>
             <select id="node-input-item" style="width:calc(100% - 170px)"></select>
         </div>
@@ -108,10 +123,11 @@
 
 <script type="text/x-red" data-help-name="hal2Value">
     <p>The Value node is used to either query a specific <i>Item</i> and send the <i>Item</i> value on to the next node, or to update an <i>Item</i> value. In the latter case the ingress function as well as all topic filters are bypassed, the value is updated directly as is. Events are triggered as usual.</p>
+    <li><strong>Category</strong>: Read a single <i>Thing</i>'s Item, or a <i>Group</i>'s own value. A group's value is computed from its members by the Event handler — average, any true, count true and so on — so it is <b>read-only</b>: use an Action node to command a group. Only groups that have been given a <b>Value</b> on the Event handler's Groups tab can be selected, and reading one needs that Event handler set on this node.</li>
     <li><strong>Action</strong>: Get value from <i>Item</i> or set value to <i>Item</i>.</li>
     <li><strong>Item</strong>: Select the <i>Item</i>.</li>
     <li><strong>Property</strong>: Source or destination for <i>Item</i> value.</li>
-    <li><strong>Item info</strong>: Output <code>msg.thing</code> and <code>msg.item</code> information. Only works when <code>msg</code> is used for output.</li>
+    <li><strong>Item info</strong>: Output <code>msg.thing</code> and <code>msg.item</code> information, or <code>msg.group</code> for a group — including how many members currently contribute a value. Only works when <code>msg</code> is used for output.</li>
     <li><strong>Name</strong>: Node name.</li>  
 </script>
 
@@ -121,7 +137,13 @@
         color: '#b3b3ff',
         defaults: {
             name:           {},
+            // Optional: only a Group source needs it, and requiring it would flag every
+            // existing Value node as invalid.
+            eventHandler:   { value: "", type: "hal2EventHandler", required: false },
+            typeSel:        { value: 'hal2Thing' },
             action:         {},
+            // For a Group source `thing` carries the group id and `item` mirrors it, exactly
+            // as hal2Event stores a group — so the required-item validation keeps working.
             thing:          {},
             thingType:      {},   
             item:           { required: true   },           
@@ -150,15 +172,22 @@
         paletteLabel: "value",
         oneditprepare: function () {
 
-            // Check if Thing has been deleted
+            var groupsList = halGetGroups(RED, $("#node-input-eventHandler").val(), 'value');
+
+            // Check if the source has been deleted. A group is not a node, so it has to be
+            // looked up in the Event handler's registry instead of with RED.nodes.node().
             if (this.thing != 0) {
                 try {
-                    let thing = RED.nodes.node(this.thing);
-                    if (typeof thing === 'undefined') {
-                        console.error('Thing ID '+this.thing+' is missing.');
+                    var stillThere = (this.typeSel === 'hal2Group')
+                        ? groupsList.some(function(g) { return g.id === this.thing; }, this)
+                        : typeof RED.nodes.node(this.thing) !== 'undefined';
+                    if (!stillThere) {
+                        console.error((this.typeSel === 'hal2Group' ? 'Group ' : 'Thing ') + this.thing +
+                                      ' is missing (or no longer has a value).');
                         this.thing = void 0;
                         this.thingType = void 0;
                         this.item = void 0;
+                        this.typeSel = void 0;
                     }
                 } catch (error) {
                         console.log('Error: '+error.message);
@@ -167,14 +196,50 @@
             var savedThing = this.thing;
             var savedType = this.thingType;
             var savedItem = this.item;
+            var savedTypeSel = this.typeSel;
 
             var thingsList = halGetThings(RED,'status');
-            if (thingsList.length == 0) {
+            if (thingsList.length == 0 && groupsList.length == 0) {
                 $("#div-main").hide();
                 $("#div-error").show();
                 return;
             }
             var thingTypeList = halGetThingTypes(RED,thingsList,true);
+
+            // Category: a Group is read-only (its value is computed from its members, so
+            // there is nothing to write to) and has no items, no filter and no history.
+            var isGroup = function() { return $("#node-input-typeSel").val() === 'hal2Group'; };
+            $("#node-input-typeSel").change(function() {
+                var group = isGroup();
+                $("#row-thing").toggle(!group);
+                $("#row-group-tip").toggle(group);
+                $("#div-item").toggle(!group);
+                if (group) {
+                    $("#thing-filter-div").hide();
+                    $("#row-notes").hide();
+                    $("#row-item-notes").hide();
+                    $("#div-type").hide();
+                    $("#node-input-action").val('get');
+                    $("#node-input-thing").children().remove();
+                    for (var d in groupsList) {
+                        $("<option value='" + groupsList[d].id + "'>" + groupsList[d].name + "</option>")
+                            .appendTo("#node-input-thing");
+                    }
+                    $("#row-thing").show();
+                    $("#label-node-input-thing").text(' Group').attr('class', 'fa fa-object-group');
+                    $("#thing-filter-button").hide();
+                    if (savedTypeSel === 'hal2Group') { $("#node-input-thing").val(savedThing); }
+                } else {
+                    $("#label-node-input-thing").text(' Thing').attr('class', 'fa fa-microchip');
+                    $("#thing-filter-button").show();
+                    $("#node-input-thing").children().remove();
+                    $("#thing-filter").trigger('change');
+                    if (savedTypeSel !== 'hal2Group') { $("#node-input-thing").val(savedThing); }
+                }
+                $("#node-input-action").prop('disabled', group);
+                $("#node-input-thing").trigger('change');
+                updateHistoryVisibility();
+            });
 
             $("#thing-filter").change(function() {
                 $("#node-input-thing").children().remove();
@@ -206,6 +271,22 @@
 
 
             $("#node-input-thing").change(function() {
+                // Groups are not nodes — the item field carries the group id, the same way
+                // hal2Event stores one, so the required-item validation is satisfied.
+                if (isGroup()) {
+                    var gid = $("#node-input-thing").val();
+                    $("#node-input-item").children().remove();
+                    if (gid) {
+                        $("<option value='" + gid + "'>" + gid + "</option>").appendTo("#node-input-item");
+                        $("#node-input-item").val(gid);
+                    }
+                    var g = groupsList.filter(function(x) { return x.id === gid; })[0];
+                    $("#group-tip").text(g
+                        ? 'Value: ' + window.hal2GroupAggregate.label(g.aggregate) +
+                          '. Read-only — use an Action node to command a group.'
+                        : '');
+                    return;
+                }
                 if ($("#node-input-thing").val() == '0') {
                     $("#div-type").show();
                     return;
@@ -265,6 +346,8 @@
             function updateHistoryVisibility() {
                 var isGet = $("#node-input-action").val() === 'get';
                 if (!isGet) { $("#row-history-mode").hide(); hideHistoryDetails(); return; }
+                // A group's value is derived and never logged, so there is no series to query.
+                if (isGroup()) { $("#row-history-mode").hide(); hideHistoryDetails(); return; }
                 var thingType;
                 if ($("#node-input-thing").val() == '0') {
                     thingType = RED.nodes.node($("#node-input-thingType").val());
@@ -304,6 +387,7 @@
 
             $("#node-input-item").change(function() {
                 $("#row-item-notes").hide();
+                if (isGroup()) { updateHistoryVisibility(); return; }
                 if ($("#node-input-thing").val() == '0') {
                     var thingType = RED.nodes.node($("#node-input-thingType").val());
                 } else {
@@ -359,16 +443,23 @@
                 $("#node-input-thingType").val(this.thingType);
             }
 
-            if (typeof this.thing !== 'undefined') {
-                $("#node-input-thing").val(this.thing);
-            } else {
-                $("#node-input-thing").val(thingsList[0].id);
-            }
+            // Category first: it repopulates the source select with either things or groups,
+            // so the saved id is resolved against the right list.
+            $("#node-input-typeSel").val(this.typeSel === 'hal2Group' ? 'hal2Group' : 'hal2Thing');
+            $("#node-input-typeSel").trigger('change');
 
-            if ($("#node-input-thing").val() == '0') {
-                $('#node-input-thingType').trigger('change');
-            } else {
-                $('#node-input-thing').trigger('change');
+            if ($("#node-input-typeSel").val() !== 'hal2Group') {
+                if (typeof this.thing !== 'undefined') {
+                    $("#node-input-thing").val(this.thing);
+                } else {
+                    $("#node-input-thing").val(thingsList[0].id);
+                }
+
+                if ($("#node-input-thing").val() == '0') {
+                    $('#node-input-thingType').trigger('change');
+                } else {
+                    $('#node-input-thing').trigger('change');
+                }
             }
 
             //Add output

--- a/core/value.js
+++ b/core/value.js
@@ -1,6 +1,8 @@
 module.exports = function(RED) {
     function hal2Value(config) {
         RED.nodes.createNode(this,config);
+        this.eventHandler = RED.nodes.getNode(config.eventHandler);
+        this.typeSel = config.typeSel;
         this.action = config.action;
         this.thing = config.thing;
         this.thingType = config.thingType;
@@ -61,7 +63,46 @@ module.exports = function(RED) {
             }
         }
 
+        // A group's value is computed by the Event handler's group engine from its members;
+        // there is nothing to write to, so this path is read-only (use hal2Action to command
+        // a group). `thing` carries the group id, exactly as hal2Event stores one.
+        function sendGroupValue(msg) {
+            if (!node.eventHandler || typeof node.eventHandler.getGroupState !== 'function') {
+                node.error('No event handler configured — a group source needs one');
+                return;
+            }
+            var rec = node.eventHandler.getGroupState(node.thing);
+            if (!rec) {
+                node.error('Group '+node.thing+' has no value — give it one on the Event handler\'s Groups tab');
+                return;
+            }
+            // No live member has a state: nothing to report, which is the same silence a
+            // thing item with no value gives rather than a made-up 0 or false.
+            if (rec.state === undefined) {
+                node.status({ fill:'grey', shape:'ring', text:'no value ('+rec.live+'/'+rec.members+' live)' });
+                return;
+            }
+            node.status({ fill:'green', shape:'dot',
+                          text: rec.state + ' ('+rec.live+'/'+rec.members+')' });
+
+            var oProp = RED.util.normalisePropertyExpression(node.outputValue);
+            switch (node.outputType) {
+                case 'flow':   node.context().flow.set(oProp[0], rec.state); break;
+                case 'global': node.context().global.set(oProp[0], rec.state); break;
+                default:       RED.util.setMessageProperty(msg, node.outputValue, rec.state, true);
+            }
+            if (node.outputInfo) {
+                msg.group = {
+                    id: node.thing, name: rec.name, function: rec.fn,
+                    members: rec.members, live: rec.live,
+                    last_update: rec.last_update, last_change: rec.last_change
+                };
+            }
+            node.send(msg);
+        }
+
         node.on('input', function(msg) {
+            if (node.typeSel === 'hal2Group') { return sendGroupValue(msg); }
             var thing;
             if (node.thing == '0') {
                 if ((typeof msg.thing !== 'undefined') && (typeof msg.thing.id !== 'undefined')) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -70,8 +70,37 @@ function thingIdFromMsg(RED,node,type,msg) {
     }
 }
 
+// Item capability predicates. The editor has its own copies in resources/hal.js (halStatusItem /
+// halCommandItem) because it cannot require() from here; these two are the runtime's, and the
+// pair must agree — an item the editor offers as a group member is one the engine must accept.
+// Item id '1' is the reserved heartbeat item, which always carries state.
+function statusCapableItem(item) {
+    if (!item) { return false; }
+    const t = item.type;
+    return (t === 'both' || t === 'status' || t === 'loopback_both' || item.id === '1');
+}
+
+function commandCapableItem(item) {
+    if (!item) { return false; }
+    const t = item.type;
+    return (t === 'both' || t === 'command' || t === 'loopback_both' || t === 'loopback_command');
+}
+
+// Is a thing currently reporting? The single definition of "offline" in hal2: it decides both
+// the `alive` flag in the MCP catalog and whether a member's value counts towards its group's
+// value. A ThingType with heartbeat checking switched off is always alive, and so is a thing
+// that has simply never had a heartbeat recorded — only an explicit false takes a thing out.
+function isThingAlive(thing) {
+    if (!thing || !thing.thingType) { return false; }
+    if (thing.thingType.hbCheck === false) { return true; }
+    return !thing.state || thing.state['1'] !== false;
+}
+
 module.exports = {
     queueSend: queueSend,
     createThrottledQueue: createThrottledQueue,
-    thingIdFromMsg: thingIdFromMsg
+    thingIdFromMsg: thingIdFromMsg,
+    statusCapableItem: statusCapableItem,
+    commandCapableItem: commandCapableItem,
+    isThingAlive: isThingAlive
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.14",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.14",
+      "version": "2.7.0",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.6",
+      "version": "2.6.7",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.12",
+      "version": "2.6.13",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.9",
+      "version": "2.6.10",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.5",
+      "version": "2.6.6",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.13",
+  "version": "2.6.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.13",
+      "version": "2.6.14",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.4",
+      "version": "2.6.5",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.8",
+      "version": "2.6.9",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.10",
+  "version": "2.6.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.10",
+      "version": "2.6.12",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.7",
+      "version": "2.6.8",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.10",
+  "version": "2.6.12",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.13",
+  "version": "2.6.14",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.14",
+  "version": "2.7.0",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/resources/group-aggregate.js
+++ b/resources/group-aggregate.js
@@ -163,9 +163,30 @@
         return undefined;
     }
 
+    // One step of a group's state record, mirroring what hal2Thing.updateState does to a
+    // thing item (core/thing.js:218-231) — because hal2Event's change filters compare
+    // state against laststate and must behave identically for both.
+    //
+    // The rule that matters: `laststate` is ALWAYS the previous value, even when it is the
+    // same value. Only `last_change` is conditional. Carrying the last *different* value
+    // forward instead would make every later update look like a change, which is exactly
+    // what "on change" is there to suppress.
+    function nextRecord(prev, value, now) {
+        prev = prev || {};
+        var changed = prev.state !== value;
+        return {
+            state:       value,
+            laststate:   prev.state,
+            last_update: now,
+            last_change: changed ? now : (prev.last_change || now),
+            changed:     changed
+        };
+    }
+
     return {
         FUNCTIONS: FUNCTIONS,
         aggregate: aggregate,
+        nextRecord: nextRecord,
         suggestFor: suggestFor,
         kindOf: kindOf,
         isFunction: isFunction,

--- a/resources/group-aggregate.js
+++ b/resources/group-aggregate.js
@@ -1,0 +1,174 @@
+// How a group turns its members' states into one value of its own.
+//
+// Loaded two ways from one source, so the function list the editor offers can never drift
+// from what the engine computes:
+//   - editor: <script src="resources/node-red-contrib-hal2/group-aggregate.js"> → window.hal2GroupAggregate
+//   - runtime/tests: require('../resources/group-aggregate')
+//
+// The module is pure: it receives the samples that count and returns a value. Deciding which
+// members count — state-capable item, thing alive, has ever reported — belongs to the engine,
+// so "no live member" and "no member at all" arrive here as the same empty list.
+
+(function (root, factory) {
+    if (typeof module !== 'undefined' && module.exports) { module.exports = factory(); }
+    else { root.hal2GroupAggregate = factory(); }
+}(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    // kind drives the order the editor offers these in, given the group's HAType. Nothing is
+    // ever hidden — a mixed group may legitimately want to count booleans.
+    var FUNCTIONS = [
+        { v: 'latest',      t: 'latest — the most recently updated member',  kind: 'any' },
+        { v: 'min',         t: 'min — the lowest value',                     kind: 'number' },
+        { v: 'max',         t: 'max — the highest value',                    kind: 'number' },
+        { v: 'average',     t: 'average — the mean of all values',           kind: 'number' },
+        { v: 'median',      t: 'median — the middle value',                  kind: 'number' },
+        { v: 'sum',         t: 'sum — all values added together',            kind: 'number' },
+        { v: 'range',       t: 'range — highest minus lowest',               kind: 'number' },
+        { v: 'anyTrue',     t: 'any true — at least one member is true',     kind: 'boolean' },
+        { v: 'allTrue',     t: 'all true — every member is true',            kind: 'boolean' },
+        { v: 'anyFalse',    t: 'any false — at least one member is false',   kind: 'boolean' },
+        { v: 'allFalse',    t: 'all false — no member is true',              kind: 'boolean' },
+        { v: 'countTrue',   t: 'count true — how many are true',             kind: 'boolean' },
+        { v: 'countFalse',  t: 'count false — how many are false',           kind: 'boolean' },
+        { v: 'percentTrue', t: 'percent true — share that are true (0–100)', kind: 'boolean' }
+    ];
+
+    // Which flavour of value a group's HAType tends to want, used to preselect a function for
+    // a new group and to order the list. Keys are HATypes from halHaTypes() in hal.js; anything
+    // not listed (modes, colors, scenes, 'other') falls through to 'any'. Only a starting
+    // point: any function can be chosen afterwards.
+    var KIND_BY_HATYPE = {
+        temperature: 'number', humidity: 'number', co2: 'number', illuminance: 'number',
+        power: 'number', battery: 'number', depth: 'number', pressure: 'number',
+        dimmer: 'number', cover: 'number', 'color temperature': 'number',
+        'target temperature': 'number', sensor: 'number',
+        switch: 'boolean', light: 'boolean', lock: 'boolean', fan: 'boolean',
+        motion: 'boolean', contact: 'boolean', smoke: 'boolean', 'water leak': 'boolean',
+        presence: 'boolean', heater: 'boolean', 'circulation pump': 'boolean',
+        airjets: 'boolean', binary_sensor: 'boolean'
+    };
+    var SUGGESTION = { number: 'average', boolean: 'anyTrue', any: 'latest' };
+
+    function suggestFor(haType) {
+        return SUGGESTION[KIND_BY_HATYPE[haType] || 'any'];
+    }
+
+    function kindOf(fn) {
+        for (var i = 0; i < FUNCTIONS.length; i++) {
+            if (FUNCTIONS[i].v === fn) { return FUNCTIONS[i].kind; }
+        }
+        return null;
+    }
+
+    function isFunction(fn) { return kindOf(fn) !== null; }
+
+    function label(fn) {
+        for (var i = 0; i < FUNCTIONS.length; i++) {
+            if (FUNCTIONS[i].v === fn) { return FUNCTIONS[i].t; }
+        }
+        return fn;
+    }
+
+    // Float noise is not a value anyone wants to see in a status badge or compare against:
+    // (21.5 + 22.3) / 2 is 21.900000000000002 in binary floating point.
+    function round(n) { return Math.round(n * 1e4) / 1e4; }
+
+    // Only genuine numbers, or the numeric strings sensors so often send. Booleans are
+    // excluded deliberately: Number(true) is 1, which would let an on/off member skew an
+    // average as if it had measured something.
+    function numbers(samples) {
+        var out = [];
+        for (var i = 0; i < samples.length; i++) {
+            var s = samples[i].state;
+            if (typeof s !== 'number' && typeof s !== 'string') { continue; }
+            if (typeof s === 'string' && s.trim() === '') { continue; }
+            var n = Number(s);
+            if (isFinite(n)) { out.push(n); }
+        }
+        return out;
+    }
+
+    // Strict, exactly like the comparison operators in lib/rules.js: a ThingType's ingress
+    // function is where 'ON' becomes true, so by the time a state reaches a group it is a
+    // real boolean or it is not a boolean at all.
+    function booleans(samples) {
+        var out = [];
+        for (var i = 0; i < samples.length; i++) {
+            if (samples[i].state === true || samples[i].state === false) { out.push(samples[i].state); }
+        }
+        return out;
+    }
+
+    function count(list, wanted) {
+        var n = 0;
+        for (var i = 0; i < list.length; i++) { if (list[i] === wanted) { n++; } }
+        return n;
+    }
+
+    // aggregate(fn, samples) → value, or undefined when nothing eligible contributed.
+    // samples: [{ state, updatedAt }]. Returning undefined rather than 0/false is what keeps a
+    // silent group from reading as a real "off" in a Gate or an Event.
+    function aggregate(fn, samples) {
+        samples = Array.isArray(samples) ? samples : [];
+        if (!samples.length) { return undefined; }
+
+        if (fn === 'latest') {
+            var best = null;
+            for (var i = 0; i < samples.length; i++) {
+                if (samples[i].state === undefined) { continue; }
+                if (!best || (samples[i].updatedAt || 0) > (best.updatedAt || 0)) { best = samples[i]; }
+            }
+            return best ? best.state : undefined;
+        }
+
+        var kind = kindOf(fn);
+        if (kind === 'number') {
+            var nums = numbers(samples);
+            if (!nums.length) { return undefined; }
+            switch (fn) {
+                case 'min': return Math.min.apply(null, nums);
+                case 'max': return Math.max.apply(null, nums);
+                case 'sum': return round(nums.reduce(function (a, b) { return a + b; }, 0));
+                case 'range': return round(Math.max.apply(null, nums) - Math.min.apply(null, nums));
+                case 'average':
+                    return round(nums.reduce(function (a, b) { return a + b; }, 0) / nums.length);
+                case 'median': {
+                    var sorted = nums.slice().sort(function (a, b) { return a - b; });
+                    var mid = Math.floor(sorted.length / 2);
+                    return sorted.length % 2
+                        ? sorted[mid]
+                        : round((sorted[mid - 1] + sorted[mid]) / 2);
+                }
+            }
+            return undefined;
+        }
+
+        if (kind === 'boolean') {
+            var bools = booleans(samples);
+            if (!bools.length) { return undefined; }
+            switch (fn) {
+                // Note these are not vacuous: an empty set returned above. 'all true' over
+                // members that are all present and all true is the only way to get true.
+                case 'anyTrue':   return count(bools, true) > 0;
+                case 'allTrue':   return count(bools, true) === bools.length;
+                case 'anyFalse':  return count(bools, false) > 0;
+                case 'allFalse':  return count(bools, true) === 0;
+                case 'countTrue': return count(bools, true);
+                case 'countFalse':return count(bools, false);
+                case 'percentTrue': return round(100 * count(bools, true) / bools.length);
+            }
+        }
+
+        return undefined;
+    }
+
+    return {
+        FUNCTIONS: FUNCTIONS,
+        aggregate: aggregate,
+        suggestFor: suggestFor,
+        kindOf: kindOf,
+        isFunction: isFunction,
+        label: label
+    };
+}));

--- a/resources/hal.js
+++ b/resources/hal.js
@@ -70,12 +70,17 @@ function halGetThings(RED,filter) {
     return filteredThingsList;
 }
 
-function halGetGroups(RED, eventHandlerId) {
+function halGetGroups(RED, eventHandlerId, filter) {
     // Groups live in the EventHandler registry (config node). For back-compat we also
     // surface any legacy hal2Group nodes still in the flow (the runtime folds these in
     // too, by node id), so existing Action/Event references keep resolving until
     // tools/migrate-groups.js is run. Registry wins on id collision.
-    // Returns [{ id, name, haType, notes, ratelimit }] sorted by name.
+    // Returns [{ id, name, haType, notes, ratelimit, aggregate }] sorted by name.
+    //
+    // filter 'value' keeps only groups that have a value function configured — the ones
+    // that can be read by Value/Gate/Event/Bayes. Expressed once here so every node that
+    // offers a group as a source applies the same rule. Legacy hal2Group nodes never have
+    // one, so they are command-only until migrated.
     var eh = eventHandlerId ? RED.nodes.node(eventHandlerId) : null;
     var groupsList = (eh && Array.isArray(eh.groups)) ? eh.groups.slice() : [];
 
@@ -87,8 +92,14 @@ function halGetGroups(RED, eventHandlerId) {
         var g = legacy[l];
         if (seen[g.id]) { continue; }
         if (eventHandlerId && g.eventHandler !== eventHandlerId) { continue; }
-        groupsList.push({ id: g.id, name: g.name, haType: 'other', notes: '', ratelimit: Number(g.ratelimit) || 0 });
+        groupsList.push({ id: g.id, name: g.name, haType: 'other', notes: '', ratelimit: Number(g.ratelimit) || 0, aggregate: '' });
         seen[g.id] = true;
+    }
+
+    if (filter === 'value') {
+        groupsList = groupsList.filter(function(x) {
+            return x && x.aggregate && window.hal2GroupAggregate.isFunction(x.aggregate);
+        });
     }
 
     groupsList.sort(function(a, b) {

--- a/resources/hal.js
+++ b/resources/hal.js
@@ -81,8 +81,23 @@ function halGetGroups(RED, eventHandlerId, filter) {
     // that can be read by Value/Gate/Event/Bayes. Expressed once here so every node that
     // offers a group as a source applies the same rule. Legacy hal2Group nodes never have
     // one, so they are command-only until migrated.
+    // A specific handler when one is given and resolves; otherwise every handler in the
+    // flow. Nodes that only gained an Event handler field recently (Value, Gate) carry an
+    // empty one on existing instances, and a group id is unique across handlers anyway —
+    // returning nothing there would silently offer an empty list instead of the real groups.
     var eh = eventHandlerId ? RED.nodes.node(eventHandlerId) : null;
-    var groupsList = (eh && Array.isArray(eh.groups)) ? eh.groups.slice() : [];
+    var groupsList = [];
+    if (eh && Array.isArray(eh.groups)) {
+        groupsList = eh.groups.slice();
+    } else if (typeof RED.nodes.eachConfig === 'function') {
+        // eachConfig, not filterNodes: the latter only walks flow nodes, and an Event
+        // handler is a config node — it would find nothing at all.
+        RED.nodes.eachConfig(function (cfg) {
+            if (cfg && cfg.type === 'hal2EventHandler' && Array.isArray(cfg.groups)) {
+                groupsList = groupsList.concat(cfg.groups);
+            }
+        });
+    }
 
     var seen = {};
     for (var i in groupsList) { seen[groupsList[i].id] = true; }
@@ -97,8 +112,10 @@ function halGetGroups(RED, eventHandlerId, filter) {
     }
 
     if (filter === 'value') {
+        var ga = (typeof window !== 'undefined') && window.hal2GroupAggregate;
         groupsList = groupsList.filter(function(x) {
-            return x && x.aggregate && window.hal2GroupAggregate.isFunction(x.aggregate);
+            if (!x || !x.aggregate) { return false; }
+            return ga ? ga.isFunction(x.aggregate) : true;
         });
     }
 

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -102,3 +102,62 @@ describe('lib/common createThrottledQueue', function () {
         assert.deepStrictEqual(sent, ['a'], 'only the immediate send happens');
     });
 });
+
+describe('lib/common item capability predicates', function () {
+    // These mirror halStatusItem / halCommandItem in resources/hal.js. The editor decides with
+    // those which items may join a group; the engine decides with these which members count.
+    // A disagreement would show as a member you could add but that never contributed.
+    const item = (type, id) => ({ type, id: id || 'x' });
+
+    it('agrees on the item types that carry state', function () {
+        assert.strictEqual(common.statusCapableItem(item('status')), true);
+        assert.strictEqual(common.statusCapableItem(item('both')), true);
+        assert.strictEqual(common.statusCapableItem(item('loopback_both')), true);
+        assert.strictEqual(common.statusCapableItem(item('command')), false);
+        assert.strictEqual(common.statusCapableItem(item('loopback_command')), false);
+    });
+
+    it('treats the reserved heartbeat item as stateful whatever its type', function () {
+        assert.strictEqual(common.statusCapableItem(item('command', '1')), true);
+        assert.strictEqual(common.statusCapableItem(item(undefined, '1')), true);
+    });
+
+    it('agrees on the item types that accept commands', function () {
+        assert.strictEqual(common.commandCapableItem(item('command')), true);
+        assert.strictEqual(common.commandCapableItem(item('both')), true);
+        assert.strictEqual(common.commandCapableItem(item('loopback_both')), true);
+        assert.strictEqual(common.commandCapableItem(item('loopback_command')), true);
+        assert.strictEqual(common.commandCapableItem(item('status')), false);
+        // The heartbeat item is readable, never commandable.
+        assert.strictEqual(common.commandCapableItem(item('status', '1')), false);
+    });
+
+    it('says no rather than throwing on a missing item', function () {
+        assert.strictEqual(common.statusCapableItem(undefined), false);
+        assert.strictEqual(common.commandCapableItem(null), false);
+    });
+});
+
+describe('lib/common isThingAlive', function () {
+    const thing = (hbCheck, aliveState) => ({
+        thingType: { hbCheck },
+        state: aliveState === undefined ? {} : { '1': aliveState }
+    });
+
+    it('is alive when the ThingType does not check heartbeats', function () {
+        // Even with a stale false left over from before the check was switched off.
+        assert.strictEqual(common.isThingAlive(thing(false, false)), true);
+        assert.strictEqual(common.isThingAlive(thing(false, undefined)), true);
+    });
+
+    it('is alive until a heartbeat explicitly says otherwise', function () {
+        assert.strictEqual(common.isThingAlive(thing(true, undefined)), true, 'never reported yet');
+        assert.strictEqual(common.isThingAlive(thing(true, true)), true);
+        assert.strictEqual(common.isThingAlive(thing(true, false)), false);
+    });
+
+    it('is not alive for a thing that cannot be resolved', function () {
+        assert.strictEqual(common.isThingAlive(undefined), false);
+        assert.strictEqual(common.isThingAlive({}), false, 'no thingType — not a usable thing');
+    });
+});

--- a/test/groupAggregate.test.js
+++ b/test/groupAggregate.test.js
@@ -176,3 +176,62 @@ describe('group-aggregate metadata', function () {
         }
     });
 });
+
+describe('group-aggregate nextRecord', function () {
+    // What hal2Event's change filters compare against. The rule this pins is the one that
+    // broke in practice: laststate is the previous value, always — carrying the last
+    // *different* value forward makes every later update look like a change, so "on change"
+    // fires on every member report even when the group's value has not moved.
+    it('always reports the previous value as laststate', function () {
+        var a = ga.nextRecord({ state: 25.25, last_change: 100 }, 25.28, 200);
+        assert.strictEqual(a.state, 25.28);
+        assert.strictEqual(a.laststate, 25.25);
+        assert.strictEqual(a.changed, true);
+        assert.strictEqual(a.last_change, 200);
+
+        // The next update leaves the value alone: state and laststate now match, which is
+        // what makes an "on change" event skip it.
+        var b = ga.nextRecord(a, 25.28, 300);
+        assert.strictEqual(b.state, 25.28);
+        assert.strictEqual(b.laststate, 25.28);
+        assert.strictEqual(b.changed, false);
+    });
+
+    it('moves last_change only on a real change, and last_update always', function () {
+        var a = ga.nextRecord({ state: 1, last_change: 100 }, 1, 200);
+        assert.strictEqual(a.last_change, 100, 'unchanged value keeps its last_change');
+        assert.strictEqual(a.last_update, 200, 'but the update time still moves');
+
+        var b = ga.nextRecord(a, 2, 300);
+        assert.strictEqual(b.last_change, 300);
+        assert.strictEqual(b.last_update, 300);
+    });
+
+    it('handles the very first computation', function () {
+        var first = ga.nextRecord(undefined, true, 500);
+        assert.strictEqual(first.state, true);
+        assert.strictEqual(first.laststate, undefined, 'no previous value to report');
+        assert.strictEqual(first.changed, true);
+        assert.strictEqual(first.last_change, 500);
+    });
+
+    it('treats a group falling silent as a change, and staying silent as none', function () {
+        // Every member goes offline: the value becomes undefined, which is a real transition.
+        var gone = ga.nextRecord({ state: 21.5, last_change: 100 }, undefined, 200);
+        assert.strictEqual(gone.state, undefined);
+        assert.strictEqual(gone.laststate, 21.5);
+        assert.strictEqual(gone.changed, true);
+
+        var still = ga.nextRecord(gone, undefined, 300);
+        assert.strictEqual(still.changed, false);
+        assert.strictEqual(still.last_change, 200, 'still pointing at when it went quiet');
+    });
+
+    it('distinguishes false from undefined', function () {
+        // A group that reads false is reporting something; one that reads undefined is not.
+        var r = ga.nextRecord({ state: undefined, last_change: 100 }, false, 200);
+        assert.strictEqual(r.changed, true);
+        assert.strictEqual(r.laststate, undefined);
+        assert.strictEqual(ga.nextRecord({ state: false }, false, 300).changed, false);
+    });
+});

--- a/test/groupAggregate.test.js
+++ b/test/groupAggregate.test.js
@@ -1,0 +1,178 @@
+'use strict';
+const assert = require('node:assert');
+const ga = require('../resources/group-aggregate');
+
+// Samples as the engine hands them over: already filtered to state-capable items on live
+// things. `at` only matters to `latest`.
+const s = (state, updatedAt) => ({ state, updatedAt: updatedAt || 0 });
+
+const TEMPS = [s(21.5, 100), s(22.3, 200), s(19.1, 150)];
+const BOOLS = [s(true), s(false), s(true)];
+
+describe('group-aggregate numeric functions', function () {
+    it('computes the obvious ones', function () {
+        assert.strictEqual(ga.aggregate('min', TEMPS), 19.1);
+        assert.strictEqual(ga.aggregate('max', TEMPS), 22.3);
+        assert.strictEqual(ga.aggregate('sum', TEMPS), 62.9);
+        assert.strictEqual(ga.aggregate('range', TEMPS), 3.2);
+    });
+
+    it('rounds away binary floating-point noise', function () {
+        // The reason rounding exists at all: this is 21.900000000000002 unrounded, which is
+        // what a status badge and a Gate comparison would otherwise see.
+        assert.strictEqual(ga.aggregate('average', [s(21.5), s(22.3)]), 21.9);
+        assert.strictEqual(ga.aggregate('sum', [s(0.1), s(0.2)]), 0.3);
+    });
+
+    it('takes the middle value for an odd count and the mean of the middle two for an even one', function () {
+        assert.strictEqual(ga.aggregate('median', TEMPS), 21.5);
+        assert.strictEqual(ga.aggregate('median', [s(1), s(2), s(3), s(10)]), 2.5);
+        assert.strictEqual(ga.aggregate('median', [s(5)]), 5);
+    });
+
+    it('accepts numeric strings, the way sensors send them', function () {
+        assert.strictEqual(ga.aggregate('average', [s('21.5'), s('22.5')]), 22);
+        assert.strictEqual(ga.aggregate('max', [s('7'), s(3)]), 7);
+    });
+
+    it('skips members that are not numbers at all', function () {
+        assert.strictEqual(ga.aggregate('average', [s(20), s('warm'), s(null), s(undefined), s(30)]), 25);
+        assert.strictEqual(ga.aggregate('min', [s(''), s('   '), s(4)]), 4);
+    });
+
+    it('does not let a boolean member count as 1 or 0', function () {
+        // Number(true) is 1. A light that is on must not drag a temperature average down.
+        assert.strictEqual(ga.aggregate('average', [s(true), s(20), s(30)]), 25);
+        assert.strictEqual(ga.aggregate('min', [s(false), s(4)]), 4);
+    });
+
+    it('is undefined when no member is numeric', function () {
+        for (const fn of ['min', 'max', 'average', 'median', 'sum', 'range']) {
+            assert.strictEqual(ga.aggregate(fn, [s('warm'), s(true), s(undefined)]), undefined, fn);
+        }
+    });
+
+    it('range over a single member is 0', function () {
+        assert.strictEqual(ga.aggregate('range', [s(21.5)]), 0);
+    });
+});
+
+describe('group-aggregate boolean functions', function () {
+    it('computes the obvious ones', function () {
+        assert.strictEqual(ga.aggregate('anyTrue', BOOLS), true);
+        assert.strictEqual(ga.aggregate('allTrue', BOOLS), false);
+        assert.strictEqual(ga.aggregate('anyFalse', BOOLS), true);
+        assert.strictEqual(ga.aggregate('allFalse', BOOLS), false);
+        assert.strictEqual(ga.aggregate('countTrue', BOOLS), 2);
+        assert.strictEqual(ga.aggregate('countFalse', BOOLS), 1);
+    });
+
+    it('agrees with itself at the edges', function () {
+        const allOn = [s(true), s(true)];
+        const allOff = [s(false), s(false)];
+        assert.strictEqual(ga.aggregate('allTrue', allOn), true);
+        assert.strictEqual(ga.aggregate('anyFalse', allOn), false);
+        assert.strictEqual(ga.aggregate('allFalse', allOff), true);
+        assert.strictEqual(ga.aggregate('anyTrue', allOff), false);
+    });
+
+    it('is strict about what counts as true', function () {
+        // hal2 normalises in the ThingType's ingress function; by the time a state reaches a
+        // group it is a real boolean. 'ON' and 1 are values, not truths.
+        const loose = [s('ON'), s(1), s('true'), s('yes')];
+        assert.strictEqual(ga.aggregate('anyTrue', loose), undefined);
+        assert.strictEqual(ga.aggregate('countTrue', loose), undefined);
+        assert.strictEqual(ga.aggregate('countTrue', [s('ON'), s(true)]), 1);
+    });
+
+    it('computes percent true as a share of the boolean members', function () {
+        assert.strictEqual(ga.aggregate('percentTrue', BOOLS), 66.6667);
+        assert.strictEqual(ga.aggregate('percentTrue', [s(true), s(false), s(false)]), 33.3333);
+        assert.strictEqual(ga.aggregate('percentTrue', [s(true), s(true)]), 100);
+        assert.strictEqual(ga.aggregate('percentTrue', [s(false)]), 0);
+        // Non-booleans do not dilute the share.
+        assert.strictEqual(ga.aggregate('percentTrue', [s(true), s(false), s('n/a')]), 50);
+    });
+
+    it('is undefined when no member is boolean', function () {
+        for (const fn of ['anyTrue', 'allTrue', 'anyFalse', 'allFalse', 'countTrue', 'countFalse', 'percentTrue']) {
+            assert.strictEqual(ga.aggregate(fn, [s(21), s('warm'), s(undefined)]), undefined, fn);
+        }
+    });
+});
+
+describe('group-aggregate latest', function () {
+    it('picks by update time, not by position in the list', function () {
+        assert.strictEqual(ga.aggregate('latest', TEMPS), 22.3);
+        assert.strictEqual(ga.aggregate('latest', [s('b', 5), s('a', 9), s('c', 1)]), 'a');
+    });
+
+    it('takes any type, including booleans and strings', function () {
+        assert.strictEqual(ga.aggregate('latest', [s(false, 1), s(true, 2)]), true);
+        assert.strictEqual(ga.aggregate('latest', [s('heat', 2), s('off', 1)]), 'heat');
+    });
+
+    it('ignores members that have never reported', function () {
+        // A member with the newest timestamp but no state must not win with undefined.
+        assert.strictEqual(ga.aggregate('latest', [s(21, 1), s(undefined, 99)]), 21);
+        assert.strictEqual(ga.aggregate('latest', [s(undefined, 99)]), undefined);
+    });
+});
+
+describe('group-aggregate empty and unknown', function () {
+    // The case this whole contract exists for: a group whose members are all offline arrives
+    // here as an empty list, and must not read as a real 0 / false in a Gate or an Event.
+    it('every function is undefined for an empty group', function () {
+        for (const f of ga.FUNCTIONS) {
+            assert.strictEqual(ga.aggregate(f.v, []), undefined, f.v);
+            assert.strictEqual(ga.aggregate(f.v, undefined), undefined, f.v);
+        }
+    });
+
+    it('every function is undefined when no member has ever reported', function () {
+        const silent = [s(undefined), s(undefined)];
+        for (const f of ga.FUNCTIONS) {
+            assert.strictEqual(ga.aggregate(f.v, silent), undefined, f.v);
+        }
+    });
+
+    it('all true / all false are never vacuously true', function () {
+        assert.strictEqual(ga.aggregate('allTrue', []), undefined);
+        assert.strictEqual(ga.aggregate('allFalse', []), undefined);
+        assert.strictEqual(ga.aggregate('allTrue', [s(undefined)]), undefined);
+    });
+
+    it('an unknown function name yields undefined rather than throwing', function () {
+        assert.strictEqual(ga.aggregate('mode', BOOLS), undefined);
+        assert.strictEqual(ga.aggregate('', BOOLS), undefined);
+        assert.strictEqual(ga.aggregate(undefined, BOOLS), undefined);
+    });
+});
+
+describe('group-aggregate metadata', function () {
+    it('classifies every function it offers', function () {
+        for (const f of ga.FUNCTIONS) {
+            assert.ok(['number', 'boolean', 'any'].includes(f.kind), f.v + ' has a kind');
+            assert.strictEqual(ga.kindOf(f.v), f.kind);
+            assert.strictEqual(ga.isFunction(f.v), true);
+            assert.ok(f.t && f.t.length, f.v + ' has a label');
+        }
+        assert.strictEqual(ga.isFunction('nope'), false);
+        assert.strictEqual(ga.kindOf('nope'), null);
+    });
+
+    it('suggests a function that matches the HAType', function () {
+        assert.strictEqual(ga.suggestFor('temperature'), 'average');
+        assert.strictEqual(ga.suggestFor('humidity'), 'average');
+        assert.strictEqual(ga.suggestFor('light'), 'anyTrue');
+        assert.strictEqual(ga.suggestFor('contact'), 'anyTrue');
+        // Anything with no natural flavour — modes, colors, mixed groups — falls back.
+        assert.strictEqual(ga.suggestFor('other'), 'latest');
+        assert.strictEqual(ga.suggestFor('ac mode'), 'latest');
+        assert.strictEqual(ga.suggestFor(undefined), 'latest');
+        // Whatever it suggests must be a function that actually exists.
+        for (const ht of ['temperature', 'light', 'other', 'dimmer', 'scene']) {
+            assert.strictEqual(ga.isFunction(ga.suggestFor(ht)), true, ht);
+        }
+    });
+});


### PR DESCRIPTION
A group has been a write-only concept: a command target with no state. That left
`hal2Value`, `hal2Gate` and `hal2Bayes` unable to use one at all, and `hal2Event` offering a Group
category that did not work.

Give a group a **Value** on the Event handler's Groups tab and it gains a state computed from its
members, shaped exactly like a Thing item's — so every reading node can consume it the same way it
consumes an item. "Alla lampor → any true" is one boolean for the whole house; "Temperatur inne →
average" is one number. A group without a Value stays exactly what it was.

## The functions

`latest`, `min`, `max`, `average`, `median`, `sum`, `range`, `any true`, `all true`, `any false`,
`all false`, `count true`, `count false`, `percent true`.

They live in `resources/group-aggregate.js`, UMD like `bayes-scale`, so the list the editor offers
cannot drift from what the engine computes. The module is pure: the engine decides which members
count and hands over only those.

## What counts is the load-bearing part

A member contributes only if its item carries state **and its Thing is alive**. A device that has
dropped off the network must not keep voting with the value it had before it went quiet — so
`any true` goes false when the last reachable lamp disappears, rather than reporting a light that
may well be dark.

The liveness rule is now `lib/common.js:isThingAlive`, shared with `get_all_states` so the group
engine and the MCP catalog cannot disagree about what offline means. The heartbeat item is not a
group member but does trigger a recompute — without that a group would keep counting a device for
as long as it stayed silent, which is the exact failure the rule exists to prevent.

Nothing eligible yields `undefined` rather than `0` or `false`, so a silent group can never read as
a real "off" in a Gate. The numeric functions skip non-numbers (a boolean member never counts as 1)
and the boolean functions are strict about `true`/`false`, matching `lib/rules.js`.

## Behaving like an item

The group emits on every member update but moves `laststate`/`last_change` exactly as
`hal2Thing.updateState` does, so `hal2Event`'s change filters behave identically whether they watch
a Thing or a group. `msg.member` says which member moved it. The emit goes straight onto the bus
rather than through `publishUpdate`: a derived value has no business in the history database, and
`hal2Value` can only read a group — use `hal2Action` to command one.

## Bugs fixed along the way

- **`hal2Event` wiped its own configuration.** Opening a group-configured node resolved the group id
  with `RED.nodes.node()`; groups are not nodes, so `thing`, `item` and `typeSel` were cleared every
  time. That was the whole of "groups don't work in Events".
- **`hal2Gate` discarded group rules** for the same reason, one layer down: the rule loader dropped
  any row whose source did not resolve to a node, so the rule vanished on the next save.
- **`hal2Gate` duplicated dynamic rules**, pre-existing: the "set by `msg.thing.id`" branch called
  `addItem` twice, once inside its guard and once after it.
- **`hal2Bayes` lost saved time-of-day steps** — `'time'` was missing from its source whitelist, so
  a time step silently reopened as a thing step.
- **`hal2Value`'s dialog would not open** when its source select had no matching option.
- The Event handler field was optional even where it is required, so setting it to *none* on a group
  source passed validation and failed at runtime.

## Testing

217 passing, up from 190. The new ones cover every function, the empty and all-offline cases that
must not read as `0`/`false`, vacuous `all true`/`all false`, strict booleans, rounding, and the
`laststate` transition that decides when "on change" fires.

Verified against the running instance: the engine picks the aggregation up at startup, and `median`
over nine live members computed 25.68 — matching the members' actual readings — with `last_change`
correctly trailing `last_update` while the value held steady.

Not yet exercised in production: a member actually going offline, and Gate/Bayes reading a group at
runtime. Only `median` has run live; the other functions are unit-tested only.
