### PR TITLE
hal2Bayes: explain the estimate, and let a rule be an AND

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,9 +306,45 @@ it with `/snapshot` appended. Leave it blank and no topic is set at all, as in t
 Output 1 carries the binary result (`payload`, `probability`, `changed`). By default it only
 emits when the result actually flips — a rule firing again while the node is already on sends
 nothing — but **Emit output 1** can be set to *every evaluation* when a downstream flow wants
-the state re-asserted continuously. Output 2 emits a snapshot (`p`, `logOdds`, `held`, active
-rules, terms, sequence state) on every evaluation, for tuning. `msg.topic` `reset` / `evidence`
-(`{ lr, halfLife? }`) are available as escape hatches.
+the state re-asserted continuously. `msg.topic` `reset` / `evidence` (`{ lr, halfLife? }`) are
+available as escape hatches.
+
+### Explaining the estimate
+
+Output 2 emits a snapshot on every evaluation, built for tuning: it says not just what the
+estimate is but which rules produced it.
+
+```json
+{ "p": 0.86, "logOdds": 1.86, "share": 108.4, "binary": true, "held": false,
+  "rules": [
+    { "id": "r1", "label": "While Hall Rörelse · Motion is true",
+      "status": "contributing", "share": 73.8, "logOdds": 2.303, "value": true },
+    { "id": "r2", "label": "When Ytterdörr · Contact is true on a full cycle and Hall Rörelse · Motion is true",
+      "status": "waiting", "share": 0, "logOdds": 0, "step": 2, "steps": 2, "deadline": 47 },
+    { "id": "r3", "label": "While Kontor Sensor · Temperature > 25",
+      "status": "condition-false", "share": 0, "logOdds": 0, "value": 23.4 }
+  ] }
+```
+
+**Every configured rule is listed, every time** — the question while tuning is usually why a rule
+is *not* firing, and a list of the ones that are cannot answer it. `status` says which case a rule
+is in:
+
+| `status` | Meaning |
+|---|---|
+| `contributing` | a level rule whose condition holds; its weight is in the estimate now |
+| `fading` | a rule that fired earlier — `age` and `halfLife` (seconds) say how far it has decayed |
+| `waiting` | a sequence partway through: `step` of `steps`, with `deadline` seconds left |
+| `armed` | a sequence at its first step, waiting to be triggered |
+| `condition-false` | evaluated and did not match — `value` is what it read |
+| `no-value` | the reading is missing, or unusable for a scaled weight |
+| `injected` | ad-hoc evidence from `msg.topic = "evidence"`, which has no rule behind it |
+
+`share` is the contribution as a percentage of the way from the prior to the on-threshold — the
+same unit the rule bars and the summary use in the editor, so what you tuned is what you read back.
+Shares add, so the contributing ones sum to the top-level `share`, and anything at or above 100 %
+reaches the threshold on its own. `label` is derived from the rule's steps, phrased as the editor
+phrases them; `logOdds` is the same contribution in the estimator's own units.
 
 ## Other recent additions
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,14 @@ available as escape hatches.
 
 ### Explaining the estimate
 
-Output 2 emits a snapshot on every evaluation, built for tuning: it says not just what the
-estimate is but which rules produced it.
+Output 2 emits a snapshot built for tuning: it says not just what the estimate is but which
+rules produced it.
+
+It fires whenever a sensor a rule watches reports, and whenever the binary result flips. It does
+**not** fire on the clock tick unless **Snapshot every tick** is enabled (Advanced) — so watching
+evidence decay between sensor reports means turning that on. The decay itself does not depend on
+it: contributions are computed from timestamps whenever the node evaluates, so the value is
+correct whenever you do look. Only the reporting is on demand.
 
 ```json
 { "p": 0.86, "logOdds": 1.86, "share": 108.4, "binary": true, "held": false,

--- a/README.md
+++ b/README.md
@@ -205,9 +205,16 @@ Everything is a **rule**, built from steps. Each step names a source and a condi
 - **on a full cycle** — a cycle: true and back to false within its limit, e.g. a door opening
   and closing (*then…*)
 
+A rule whose steps are **all conditions** is not a sequence but an **AND**: its weight applies for
+as long as every one of them holds at the same time. "While it is 09:00–10:00 *and* the terrace is
+above 100 lux" is one weight with two conditions. A rule that opens with a condition but waits for
+an event later cannot work — nothing completes that first step — and the editor says so on the
+rule; in the snapshot it reads as `never-fires`.
+
 Timing sits on a second line under a step, only where it applies: *within N s of the previous
 step* is how long that step has to happen, and *stays on for at most N s* is how long a cycle may
 stay true — a door held open longer than that is not a pass-through, so the rule does not advance.
+In an AND there is no previous step to be soon after, so no window is shown.
 
 A **time** source is a window of the day rather than a sensor: start and end in 24-hour format
 plus the weekdays it applies on. It may cross midnight (22:00–06:00), start is inclusive and end
@@ -336,9 +343,10 @@ is in:
 | `fading` | a rule that fired earlier — `age` and `halfLife` (seconds) say how far it has decayed |
 | `waiting` | a sequence partway through: `step` of `steps`, with `deadline` seconds left |
 | `armed` | a sequence at its first step, waiting to be triggered |
-| `condition-false` | evaluated and did not match — `value` is what it read |
+| `condition-false` | evaluated and did not match — `value` is what it read, and `failedStep` which condition broke it |
 | `no-value` | the reading is missing, or unusable for a scaled weight |
 | `injected` | ad-hoc evidence from `msg.topic = "evidence"`, which has no rule behind it |
+| `never-fires` | the rule opens with a condition but waits for an event later, so nothing can start it |
 
 `share` is the contribution as a percentage of the way from the prior to the on-threshold — the
 same unit the rule bars and the summary use in the editor, so what you tuned is what you read back.

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -557,6 +557,11 @@
                     var opHandler = function() {
                         var op = opSel.val();
                         valWrap.toggle(op !== 'true' && op !== 'false');
+                        // "> 100" wants a number; say so for you rather than leaving a string
+                        // that only compares correctly by JavaScript's coercion rules.
+                        if (halShouldDefaultNumeric(op, valField.typedInput('type'), valField.typedInput('value'))) {
+                            valField.typedInput('type', 'num');
+                        }
                     };
                     opSel.change(opHandler);
 

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -125,6 +125,10 @@
         <li><b>on a full cycle</b> &mdash; a cycle: true and back to false within its limit, e.g. a
             door opening and closing. Reads <i>then&hellip;</i></li>
     </ul>
+    <p>A rule whose steps are <b>all conditions</b> is not a sequence but an <b>AND</b>: its weight
+    applies while every one of them holds at the same time, and it reads <i>While A and B</i>. A rule
+    that opens with a condition but waits for an event later cannot work &mdash; nothing completes
+    that first step &mdash; and the rule says so.</p>
     <p>Timing appears on a second line under a step, only where it applies: <i>within N s of the
     previous step</i> is how long that step has to happen, and <i>stays on for at most N s</i> is how
     long a cycle may stay true &mdash; a door held open longer than that is not a pass-through and the
@@ -241,9 +245,11 @@
             with <code>deadline</code> seconds left of its window</li>
         <li><b>armed</b> &mdash; a sequence at its first step, waiting to be triggered</li>
         <li><b>condition-false</b> &mdash; evaluated and did not match; <code>value</code> shows what
-            it read</li>
+            it read and <code>failedStep</code> which condition broke it</li>
         <li><b>no-value</b> &mdash; the reading is missing, or unusable for a scaled weight</li>
         <li><b>injected</b> &mdash; ad-hoc evidence from <code>msg.topic = "evidence"</code></li>
+        <li><b>never-fires</b> &mdash; the rule opens with a condition but waits for an event later,
+            so nothing can start it</li>
     </ul>
 
     <h3>Notes</h3>
@@ -383,9 +389,13 @@
                     return Math.abs(a) >= Math.abs(b) ? a : b;
                 }
 
+                function isCondition(st) {
+                    return !!st && (st.pattern === 'is' || st.pattern === 'isOrBecomes');
+                }
                 function isContinuous(rule) {
-                    // A lone level check is the continuous case: "while X is true".
-                    return rule.steps.length === 1 && rule.steps[0].pattern === 'is';
+                    // A rule made only of level checks is the continuous case: one weight that
+                    // applies while every condition holds at once — "while X and Y".
+                    return rule.steps.length > 0 && rule.steps.every(isCondition);
                 }
 
                 function ruleHalfLifeS(rule) {
@@ -683,7 +693,9 @@
                         // A condition reads "and …"; an event reads "then …".
                         var isCond = (pat === 'is' || pat === 'isOrBecomes');
                         el.find('.bs-lead').text(i === 0 ? (cont ? 'While' : 'When') : (isCond ? 'and' : 'then'));
-                        var showWindow = i > 0 && pat !== 'is';
+                        // In an AND there is no "previous step" to be soon after — every
+                        // condition is judged at the same instant.
+                        var showWindow = i > 0 && pat !== 'is' && !cont;
                         var showCycle = (pat === 'cycle');
                         timing.find('.bs-window-span').toggle(showWindow);
                         timing.find('.bs-cycle-span').toggle(showCycle);
@@ -716,10 +728,13 @@
                     });
 
                     // A level check cannot start a sequence — nothing would trigger it.
-                    var deadTrigger = rule.steps.length > 1 &&
-                        (rule.steps[0].pattern === 'is' || rule.steps[0].pattern === 'isOrBecomes');
+                    // Only a rule that mixes a leading condition with a later event is dead:
+                    // nothing completes the first step. All conditions is an AND, and an event
+                    // first is an ordinary sequence.
+                    var deadTrigger = rule.steps.length > 1 && !isContinuous(rule) &&
+                        isCondition(rule.steps[0]);
                     container.find('.br-warning')
-                        .text(deadTrigger ? 'The first step is a condition, so nothing triggers this rule — use "on change" or "on a full cycle".' : '')
+                        .text(deadTrigger ? 'This rule starts with a condition but waits for an event later, so nothing can trigger it — make the first step "on change" or "on a full cycle", or make every step a condition.' : '')
                         .toggle(deadTrigger);
 
                     var scaled = (rule.strength === 'scaled' && rule.steps.length === 1);

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -230,6 +230,10 @@
     <code>{ p, logOdds, share, binary, held, rules }</code>, on every sensor evaluation (and every
     tick if enabled). Wire output 1 onward like any other message to record the result on a Thing
     &mdash; the node has no side channel into the object model.</p>
+    <p>A snapshot follows every sensor report and every flip of the result. The clock tick does not
+    produce one unless <b>Snapshot every tick</b> is enabled &mdash; turn it on to watch evidence
+    decay between reports. Decay does not depend on it: contributions are computed from timestamps
+    at evaluation, so the value is right whenever the node does look.</p>
     <p><b>rules</b> lists <i>every</i> rule on every snapshot, not only the ones firing &mdash; while
     tuning, the question is usually why a rule is <em>not</em> contributing. Each entry carries a
     <code>label</code> read off its own steps, the <code>value</code> its source holds right now, its

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -681,11 +681,29 @@
                         var src = el.find('.bs-src').val();
                         var isTime = src === 'time';
 
+                        // The first step decides what kind of rule this is, and the rest
+                        // follow from it. Start with a condition and the rule is an AND: every
+                        // later step is judged at the same instant, so there is no edge to
+                        // wait for and nothing to be "soon" after — only "now" is meaningful,
+                        // and an event there would make the rule unreachable instead.
+                        var condFirst = isCondition(rule.steps[0]);
                         var allowed = isTime ? ['is']
+                                    // Only narrow a step that is already a condition. An event
+                                    // after a leading condition is a broken rule, not an AND —
+                                    // coercing it would quietly turn "then the door opens" into
+                                    // "and the door is open". Leave it, and let the warning say so.
+                                    : (i > 0 && condFirst && isCondition(rule.steps[i])) ? ['is']
                                     : (src === 'thing' || src === 'group') ? (i === 0 ? ['is', 'becomes', 'cycle'] : ALL_PATTERNS)
                                     : (i === 0 ? ['is'] : ['is', 'isOrBecomes']);
                         var patSel = el.find('.bs-pattern');
-                        setPatternOptions(patSel, allowed, patSel.val());
+                        var wasPat = patSel.val();
+                        setPatternOptions(patSel, allowed, wasPat);
+                        // Say it once rather than silently rewriting: in an AND the two behave
+                        // identically, so this is showing what already happens, not a change.
+                        if (wasPat === 'isOrBecomes' && allowed.indexOf('isOrBecomes') < 0 && i > 0 && condFirst) {
+                            RED.notify('hal2Bayes: every step is a condition, so this rule is an "and" — ' +
+                                       '"now or soon" has nothing to wait for and reads as "now".', 'warning');
+                        }
                         patSel.toggle(allowed.length > 1);
                         el.find('.bs-val-wrap').toggle(!isTime && ['true', 'false'].indexOf(el.find('.bs-op').val()) < 0);
 
@@ -693,9 +711,7 @@
                         // A condition reads "and …"; an event reads "then …".
                         var isCond = (pat === 'is' || pat === 'isOrBecomes');
                         el.find('.bs-lead').text(i === 0 ? (cont ? 'While' : 'When') : (isCond ? 'and' : 'then'));
-                        // In an AND there is no "previous step" to be soon after — every
-                        // condition is judged at the same instant.
-                        var showWindow = i > 0 && pat !== 'is' && !cont;
+                        var showWindow = i > 0 && pat !== 'is';
                         var showCycle = (pat === 'cycle');
                         timing.find('.bs-window-span').toggle(showWindow);
                         timing.find('.bs-cycle-span').toggle(showCycle);

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -554,13 +554,19 @@
                         fillItemSelect(itemSel, thingSel.val(), (thingSel.val() === step.thing) ? step.item : null);
                     });
                     // Hide the wrapper, not just the widget, so its flex space collapses too.
+                    // The value types an operator can actually work with, following what
+                    // hal2Event and hal2Gate already do: a comparison that can only mean a
+                    // number offers only num, and regex offers only re — where the estimator
+                    // needs a real RegExp and a string would throw at evaluation.
                     var opHandler = function() {
                         var op = opSel.val();
                         valWrap.toggle(op !== 'true' && op !== 'false');
-                        // "> 100" wants a number; say so for you rather than leaving a string
-                        // that only compares correctly by JavaScript's coercion rules.
-                        if (halShouldDefaultNumeric(op, valField.typedInput('type'), valField.typedInput('value'))) {
-                            valField.typedInput('type', 'num');
+                        if (op === 'regex') {
+                            valField.typedInput('types', ['re']).typedInput('type', 're');
+                        } else if (halNumericOperator(op)) {
+                            valField.typedInput('types', ['num']).typedInput('type', 'num');
+                        } else {
+                            valField.typedInput('types', ['str', 'num', 'bool', 're']);
                         }
                     };
                     opSel.change(opHandler);

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -222,10 +222,29 @@
     <p><b>1:</b> the binary result &mdash; <code>payload</code> true/false, <code>probability</code>,
     <code>changed</code>. By default this only emits when the result actually flips, so a rule firing
     again while the node is already on sends nothing; set <b>Emit output 1</b> to <i>every evaluation</i>
-    to have the state re-asserted continuously instead. <b>2:</b> snapshot
-    <code>{ p, logOdds, binary, held, activeRules, terms, fsm }</code> on every sensor evaluation
-    (and every tick if enabled). Wire output 1 onward like any other message to record the result on
-    a Thing &mdash; the node has no side channel into the object model.</p>
+    to have the state re-asserted continuously instead. <b>2:</b> the snapshot,
+    <code>{ p, logOdds, share, binary, held, rules }</code>, on every sensor evaluation (and every
+    tick if enabled). Wire output 1 onward like any other message to record the result on a Thing
+    &mdash; the node has no side channel into the object model.</p>
+    <p><b>rules</b> lists <i>every</i> rule on every snapshot, not only the ones firing &mdash; while
+    tuning, the question is usually why a rule is <em>not</em> contributing. Each entry carries a
+    <code>label</code> read off its own steps, the <code>value</code> its source holds right now, its
+    <code>share</code> of the way to the on-threshold (the same percentage the bars above use, and it
+    adds up: the contributing shares sum to the snapshot's <code>share</code>), and a
+    <code>status</code>:</p>
+    <ul>
+        <li><b>contributing</b> &mdash; a level rule whose condition holds; its weight is in the
+            estimate now</li>
+        <li><b>fading</b> &mdash; fired earlier; <code>age</code> and <code>halfLife</code> in seconds
+            say how far it has decayed</li>
+        <li><b>waiting</b> &mdash; a sequence partway through: <code>step</code> of <code>steps</code>,
+            with <code>deadline</code> seconds left of its window</li>
+        <li><b>armed</b> &mdash; a sequence at its first step, waiting to be triggered</li>
+        <li><b>condition-false</b> &mdash; evaluated and did not match; <code>value</code> shows what
+            it read</li>
+        <li><b>no-value</b> &mdash; the reading is missing, or unusable for a scaled weight</li>
+        <li><b>injected</b> &mdash; ad-hoc evidence from <code>msg.topic = "evidence"</code></li>
+    </ul>
 
     <h3>Notes</h3>
     <p>The estimate is persisted in node context (the event handler's context store), so it survives

--- a/core/bayes.js
+++ b/core/bayes.js
@@ -2,6 +2,7 @@ module.exports = function(RED) {
     const { createBayes } = require('../lib/bayes');
     const scale = require('../resources/bayes-scale');
     const bayesTime = require('../resources/bayes-time');
+    const bayesLabel = require('../resources/bayes-label');
 
     function hal2Bayes(config) {
         RED.nodes.createNode(this, config);
@@ -93,6 +94,40 @@ module.exports = function(RED) {
             }).filter(r => r.steps.length > 0)
         };
 
+        // ---- rule labels ----
+        // The snapshot names rules rather than showing ids, and only this layer can turn a
+        // thing id into "Kontor Sensor". The phrasing itself lives in resources/bayes-label.js
+        // so the editor can adopt the same wording later.
+        function stepNames(step) {
+            switch (step.src) {
+                case 'group': {
+                    const rec = node.eventHandler && typeof node.eventHandler.getGroupState === 'function'
+                        ? node.eventHandler.getGroupState(step.group) : null;
+                    return { source: (rec && rec.name) || step.group };
+                }
+                case 'flow':   return { source: 'flow.' + step.prop };
+                case 'global': return { source: 'global.' + step.prop };
+                case 'env':    return { source: 'env.' + step.prop };
+                case 'time':   return { window: bayesTime.describe(step) };
+                default: {
+                    const thing = RED.nodes.getNode(step.thing);
+                    if (!thing || !thing.thingType || !Array.isArray(thing.thingType.items)) {
+                        return { source: step.thing };
+                    }
+                    const item = thing.thingType.items.find(i => i.id === step.item);
+                    return { source: thing.name + (item ? ' · ' + item.name : '') };
+                }
+            }
+        }
+        function labelRules() {
+            for (const rule of cfg.rules) {
+                rule.label = bayesLabel.describeRule(rule, rule.steps.map(stepNames));
+            }
+        }
+        // Once now, in case this node is deployed on its own and everything it refers to is
+        // already up, and again on flows:started when a full deploy has registered the things.
+        labelRules();
+
         // Like hal2Event: a blank topic leaves msg.topic alone rather than inventing one.
         const topic          = config.topic || '';
         const withTopic      = (msg, suffix) => {
@@ -147,8 +182,8 @@ module.exports = function(RED) {
         function snapshotPayload(result) {
             return {
                 p: Number(result.p.toFixed(4)), logOdds: Number(result.logOdds.toFixed(4)),
-                binary: result.binary, held: result.held,
-                activeRules: result.activeRules, terms: result.terms, fsm: result.fsm
+                share: result.share, binary: result.binary, held: result.held,
+                rules: result.rules
             };
         }
 
@@ -202,8 +237,9 @@ module.exports = function(RED) {
             run(snapshotOnTick);
         }, tickMs);
 
-        // Initial evaluation once all nodes are registered (things resolvable).
-        const onStarted = function() { run(false); };
+        // Initial evaluation once all nodes are registered (things resolvable) — which is also
+        // the first moment the labels can name anything.
+        const onStarted = function() { labelRules(); run(false); };
         RED.events.on('flows:started', onStarted);
 
         // ---- msg input: escape hatches ----

--- a/lib/bayes.js
+++ b/lib/bayes.js
@@ -100,10 +100,14 @@ function createBayes(cfg) {
         const cmp = COMPARE[step.operator];
         if (!cmp) { return false; }
         if (step.operator === 'true' || step.operator === 'false') { return cmp(raw); }
-        let b;
-        try { b = CONVERTERS[step.valueType || 'str'](step.value); }
-        catch (e) { return false; }
-        return cmp(raw, b);
+        // The comparison is guarded as well as the conversion. A saved rule can pair an
+        // operator with a value type that cannot serve it — regex against a plain string,
+        // where COMPARE.regex calls b.test — and one bad rule must not take the whole
+        // evaluation down with it. A condition that cannot be evaluated has not matched.
+        try {
+            const b = CONVERTERS[step.valueType || 'str'](step.value);
+            return cmp(raw, b);
+        } catch (e) { return false; }
     }
 
     function fsmFor(ruleId) {

--- a/lib/bayes.js
+++ b/lib/bayes.js
@@ -61,6 +61,12 @@ function createBayes(cfg) {
         return share === null ? null : clampLn(share * gain);
     }
 
+    // Reporting arithmetic. A share is the contribution as a percentage of the distance from
+    // the prior to the on-threshold — the unit the editor's bars and summary already use, and
+    // additive for the same reason log-odds are.
+    const round3    = x => Number(x.toFixed(3));
+    const sharePct  = ln => Number((100 * ln / gain).toFixed(1));
+
     const ruleById = new Map(cfg.rules.map(r => [r.id, r]));
     // A lone level check is the continuous case: "while X is true".
     const isContinuous = r => r.steps.length === 1 && r.steps[0].pattern === 'is';
@@ -243,31 +249,71 @@ function createBayes(cfg) {
         // Full evaluation. resolveState(step) → current raw value for continuous rules.
         evaluate(resolveState, now) {
             let L = priorLogit;
-            const active = [];
             let positiveActive = false;
             let negativeActive = false;
+            // ruleId → report entry. Built as we go so the explanation is the same pass that
+            // computes the estimate: a rule cannot be described as contributing unless its
+            // weight really went into L.
+            const report = new Map();
+            const entry = rule => {
+                const e = { id: rule.id, label: rule.label || rule.id, status: 'armed',
+                            share: 0, logOdds: 0 };
+                report.set(rule.id, e);
+                return e;
+            };
 
             for (const rule of cfg.rules) {
+                const e = entry(rule);
                 if (!isContinuous(rule)) { continue; }
                 // One read, feeding both the condition and a scaled weight.
                 const raw = resolveState(rule.steps[0]);
+                if (raw !== undefined) { e.value = raw; }
                 if (conditionMatches(rule.steps[0], raw)) {
                     const l0 = ruleLn(rule, raw);
-                    if (l0 === null) { continue; }   // unusable reading — no contribution
+                    if (l0 === null) {
+                        // The condition holds but the weight cannot be computed — a scaled
+                        // rule handed something that is not a number.
+                        e.status = 'no-value';
+                        continue;
+                    }
                     L += l0;
-                    active.push(rule.id);
+                    e.status = 'contributing';
+                    e.logOdds = round3(l0);
+                    e.share = sharePct(l0);
                     if (l0 > 0) { positiveActive = true; }
                     if (l0 < 0) { negativeActive = true; }
+                } else {
+                    e.status = raw === undefined ? 'no-value' : 'condition-false';
                 }
             }
 
-            const terms = [];
             for (const t of S.terms) {
                 const contrib = t.l0 * Math.pow(2, -(now - t.ts) / t.halfLifeMs);
                 L += contrib;
-                terms.push({ ruleId: t.ruleId, contribution: Number(contrib.toFixed(3)) });
+                // Injected evidence has no configured rule behind it, so it gets its own entry.
+                const e = report.get(t.ruleId) ||
+                          report.set(t.ruleId, { id: t.ruleId, label: t.ruleId, status: 'injected',
+                                                 share: 0, logOdds: 0 }).get(t.ruleId);
+                if (e.status !== 'injected') { e.status = 'fading'; }
+                // A rule that fired twice holds two terms; they add, exactly as they do in L.
+                e.logOdds = round3(e.logOdds + contrib);
+                e.share = sharePct(e.logOdds);
+                e.age = Math.max(0, Math.round((now - t.ts) / 1000));
+                e.halfLife = Math.round(t.halfLifeMs / 1000);
                 if (contrib > 0 && Math.abs(contrib) >= PRUNE_BELOW) { positiveActive = true; }
                 if (contrib < 0 && Math.abs(contrib) >= PRUNE_BELOW) { negativeActive = true; }
+            }
+
+            // Sequences that are partway through: not contributing yet, but the reason a rule
+            // looks idle is usually that it is parked on a step waiting for something.
+            for (const rule of cfg.rules) {
+                const f = S.fsm[rule.id];
+                const e = report.get(rule.id);
+                if (!f || !e || e.status !== 'armed' || f.stepIndex === 0) { continue; }
+                e.status = 'waiting';
+                e.step = f.stepIndex + 1;
+                e.steps = rule.steps.length;
+                if (f.deadline !== null) { e.deadline = Math.max(0, Math.round((f.deadline - now) / 1000)); }
             }
 
             L = clampLn(L);
@@ -293,9 +339,9 @@ function createBayes(cfg) {
             }
             S.lastP = p;
 
-            return { p, logOdds: L, binary: S.binary, changed, held,
-                     activeRules: active, terms,
-                     fsm: JSON.parse(JSON.stringify(S.fsm)) };
+            return { p, logOdds: L, share: sharePct(L - priorLogit),
+                     binary: S.binary, changed, held,
+                     rules: [...report.values()] };
         },
 
         // msg-input escape hatches

--- a/lib/bayes.js
+++ b/lib/bayes.js
@@ -68,8 +68,16 @@ function createBayes(cfg) {
     const sharePct  = ln => Number((100 * ln / gain).toFixed(1));
 
     const ruleById = new Map(cfg.rules.map(r => [r.id, r]));
-    // A lone level check is the continuous case: "while X is true".
-    const isContinuous = r => r.steps.length === 1 && r.steps[0].pattern === 'is';
+    // A rule made only of level checks is the continuous case: its weight applies for as long
+    // as every one of them holds at once. "While it is 09:00–10:00 and the terrace is above
+    // 100 lux" is one weight with two conditions, not a sequence — a condition is not an event,
+    // so nothing would ever drive it forward.
+    const isCondition  = st => st.pattern === 'is' || st.pattern === 'isOrBecomes';
+    const isContinuous = r => r.steps.every(isCondition);
+    // …and a rule that opens with a condition but waits for an event later can never start:
+    // the first step has no edge to complete it. The editor warns about this while you write
+    // it; the snapshot reports it so an already-saved one does not just sit there looking idle.
+    const neverFires = r => !isContinuous(r) && isCondition(r.steps[0]);
 
     const stepKey = (ruleId, i) => ruleId + ':' + i;
 
@@ -264,14 +272,26 @@ function createBayes(cfg) {
 
             for (const rule of cfg.rules) {
                 const e = entry(rule);
+                if (neverFires(rule)) { e.status = 'never-fires'; continue; }
                 if (!isContinuous(rule)) { continue; }
-                // One read, feeding both the condition and a scaled weight.
+
+                // Every step has to hold at once. The first one's reading is also what a
+                // scaled weight follows, so it is read whatever the outcome.
                 const raw = resolveState(rule.steps[0]);
                 if (raw !== undefined) { e.value = raw; }
-                if (conditionMatches(rule.steps[0], raw)) {
+                let holds = true;
+                for (let i = 0; i < rule.steps.length && holds; i++) {
+                    const v = i === 0 ? raw : resolveState(rule.steps[i]);
+                    holds = conditionMatches(rule.steps[i], v);
+                    // Name the step that failed: with several conditions, "which one" is the
+                    // whole question.
+                    if (!holds && rule.steps.length > 1) { e.failedStep = i + 1; }
+                }
+
+                if (holds) {
                     const l0 = ruleLn(rule, raw);
                     if (l0 === null) {
-                        // The condition holds but the weight cannot be computed — a scaled
+                        // The conditions hold but the weight cannot be computed — a scaled
                         // rule handed something that is not a number.
                         e.status = 'no-value';
                         continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.6",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.7.6",
+      "version": "2.8.0",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.7.4",
+      "version": "2.7.5",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.7.5",
+      "version": "2.7.6",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.6",
+  "version": "2.8.0",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/resources/bayes-label.js
+++ b/resources/bayes-label.js
@@ -1,0 +1,93 @@
+// How a hal2Bayes rule reads as a sentence, for the snapshot on output 2.
+//
+// Loaded the same two ways as the other bayes modules, so the editor can adopt this wording
+// later without a second implementation of it:
+//   - editor: <script src="resources/node-red-contrib-hal2/bayes-label.js"> → window.hal2BayesLabel
+//   - runtime/tests: require('../resources/bayes-label')
+//
+// Pure: names arrive already resolved. Only core/bayes.js can reach RED.nodes to turn a thing
+// id into "Kontor Sensor", so it does that and hands the result over — the same separation
+// lib/bayes.js uses for resolveState.
+
+(function (root, factory) {
+    if (typeof module !== 'undefined' && module.exports) { module.exports = factory(); }
+    else { root.hal2BayesLabel = factory(); }
+}(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    // Operator wording. The symbols are what the editor shows, so they are what a rule is
+    // recognised by; only the two unary ones read better as words.
+    var OPERATORS = {
+        eq: '==', neq: '!=', lt: '<', lte: '<=', gt: '>', gte: '>=',
+        cont: 'contains', regex: 'matches',
+        'true': 'is true', 'false': 'is false'
+    };
+
+    // Trailing qualifier for the patterns that are events rather than conditions. 'is' and
+    // 'isOrBecomes' carry none: the lead word already said they are conditions.
+    var PATTERNS = {
+        becomes: 'on change',
+        cycle: 'on a full cycle'
+    };
+
+    // The lead word, matching what the editor prints in .bs-lead (core/bayes.html). A rule
+    // that is one level check reads "While …"; anything that waits for an event reads
+    // "When …", and later steps read "and" or "then" depending on their own pattern.
+    function lead(step, index, continuous) {
+        if (index === 0) { return continuous ? 'While' : 'When'; }
+        return (step.pattern === 'is' || step.pattern === 'isOrBecomes') ? 'and' : 'then';
+    }
+
+    // A rule is continuous when it is a single level check — the same test the estimator
+    // uses to decide whether a rule holds a weight or fires one (lib/bayes.js).
+    function isContinuous(rule) {
+        return !!(rule && rule.steps && rule.steps.length === 1 && rule.steps[0].pattern === 'is');
+    }
+
+    // names: { source, window } — `source` is the resolved subject ("Kontor Sensor ·
+    // Temperature", "flow.guestMode"), `window` the phrasing for a time step. Both optional;
+    // an unresolvable source falls back to whatever the step carries so a label is never empty.
+    function describeStep(step, names, index, continuous) {
+        if (!step) { return ''; }
+        names = names || {};
+        var parts = [lead(step, index || 0, continuous)];
+
+        if (step.src === 'time') {
+            // The operator is inside/outside for a window, which the editor words that way too.
+            parts.push(names.window || 'time window');
+            parts.push(step.operator === 'false' ? 'is outside' : 'is inside');
+            return parts.join(' ');
+        }
+
+        parts.push(names.source || step.thing || step.group || step.prop || step.src);
+
+        var op = OPERATORS[step.operator] || step.operator || '';
+        if (op) { parts.push(op); }
+        // A unary operator has already said everything; a comparison needs its value.
+        if (step.operator !== 'true' && step.operator !== 'false' &&
+            step.value !== undefined && step.value !== '') {
+            parts.push(String(step.value));
+        }
+        if (PATTERNS[step.pattern]) { parts.push(PATTERNS[step.pattern]); }
+        return parts.join(' ');
+    }
+
+    // The whole rule, its steps read in order. names is a parallel array, one per step.
+    function describeRule(rule, names) {
+        if (!rule || !rule.steps || !rule.steps.length) { return ''; }
+        var continuous = isContinuous(rule);
+        var out = [];
+        for (var i = 0; i < rule.steps.length; i++) {
+            out.push(describeStep(rule.steps[i], (names || [])[i], i, continuous));
+        }
+        return out.join(' ');
+    }
+
+    return {
+        OPERATORS: OPERATORS,
+        PATTERNS: PATTERNS,
+        isContinuous: isContinuous,
+        describeStep: describeStep,
+        describeRule: describeRule
+    };
+}));

--- a/resources/bayes-label.js
+++ b/resources/bayes-label.js
@@ -38,10 +38,14 @@
         return (step.pattern === 'is' || step.pattern === 'isOrBecomes') ? 'and' : 'then';
     }
 
-    // A rule is continuous when it is a single level check — the same test the estimator
-    // uses to decide whether a rule holds a weight or fires one (lib/bayes.js).
+    // A rule is continuous when every step is a level check — the same test the estimator uses
+    // to decide whether a rule holds a weight or fires one (lib/bayes.js). Several conditions
+    // read as one "While A and B": they all have to hold at once.
+    function isCondition(step) {
+        return !!step && (step.pattern === 'is' || step.pattern === 'isOrBecomes');
+    }
     function isContinuous(rule) {
-        return !!(rule && rule.steps && rule.steps.length === 1 && rule.steps[0].pattern === 'is');
+        return !!(rule && rule.steps && rule.steps.length && rule.steps.every(isCondition));
     }
 
     // names: { source, window } — `source` is the resolved subject ("Kontor Sensor ·
@@ -86,6 +90,7 @@
     return {
         OPERATORS: OPERATORS,
         PATTERNS: PATTERNS,
+        isCondition: isCondition,
         isContinuous: isContinuous,
         describeStep: describeStep,
         describeRule: describeRule

--- a/resources/hal.js
+++ b/resources/hal.js
@@ -29,22 +29,11 @@ function halOperators(ops) {
     return operators;    
 }
 
-// Comparisons that can only mean a number. Used to pick the value field's type for you when
-// you choose one of them — a default, never a lock: the type selector still offers everything,
-// so a string or a flow reference remains one click away.
+// Comparisons that can only mean a number. The editors narrow the value field's type list to
+// num when one of these is chosen, the way hal2Event and hal2Gate have always done — offering
+// a string for "greater than" only invites a comparison that works by coercion or not at all.
 function halNumericOperator(op) {
     return ['lt', 'lte', 'gt', 'gte'].indexOf(op) >= 0;
-}
-
-// Should choosing `op` switch the value field to num? Only when nothing would be lost by it:
-// the field is still on its default string type and holds either nothing or something that
-// already reads as a number. A deliberate choice — a msg/flow reference, or text like "warm" —
-// is left exactly as it is.
-function halShouldDefaultNumeric(op, currentType, currentValue) {
-    if (!halNumericOperator(op)) { return false; }
-    if (currentType !== 'str') { return false; }
-    var v = (currentValue === undefined || currentValue === null) ? '' : String(currentValue).trim();
-    return v === '' || (!isNaN(Number(v)) && isFinite(Number(v)));
 }
 
 function halTypeMQTT() {

--- a/resources/hal.js
+++ b/resources/hal.js
@@ -29,6 +29,24 @@ function halOperators(ops) {
     return operators;    
 }
 
+// Comparisons that can only mean a number. Used to pick the value field's type for you when
+// you choose one of them — a default, never a lock: the type selector still offers everything,
+// so a string or a flow reference remains one click away.
+function halNumericOperator(op) {
+    return ['lt', 'lte', 'gt', 'gte'].indexOf(op) >= 0;
+}
+
+// Should choosing `op` switch the value field to num? Only when nothing would be lost by it:
+// the field is still on its default string type and holds either nothing or something that
+// already reads as a number. A deliberate choice — a msg/flow reference, or text like "warm" —
+// is left exactly as it is.
+function halShouldDefaultNumeric(op, currentType, currentValue) {
+    if (!halNumericOperator(op)) { return false; }
+    if (currentType !== 'str') { return false; }
+    var v = (currentValue === undefined || currentValue === null) ? '' : String(currentValue).trim();
+    return v === '' || (!isNaN(Number(v)) && isFinite(Number(v)));
+}
+
 function halTypeMQTT() {
     return {
         value: "mqtt",

--- a/test/bayes.test.js
+++ b/test/bayes.test.js
@@ -884,3 +884,78 @@ describe('snapshot report', function() {
         assert.strictEqual(byId(r, 'b').label, 'b', 'unlabelled rules stay identifiable');
     });
 });
+
+describe('multi-condition rules', function() {
+    // A rule made only of level checks is one weight with several conditions, not a sequence.
+    // Before this it fell through to the sequence machinery and could never fire: a condition
+    // is not an event, so nothing ever drove the first step forward.
+    const twoConditions = () => ({ id: 'and', lr: 10, halfLifeMs: null, steps: [
+        step('is', { thing: 'a', operator: 'gt', value: '100', valueType: 'num' }),
+        step('is', { thing: 'b' })
+    ]});
+
+    it('holds its weight only while every condition holds at once', function() {
+        const b = createBayes(cfgOf({ rules: [twoConditions()] }));
+        const state = { a: 150, b: true };
+        const R = stateOf(state);
+
+        assert.strictEqual(active(b.evaluate(R, 0)).length, 1, 'both hold');
+        state.b = false;
+        assert.strictEqual(active(b.evaluate(R, MIN)).length, 0, 'second condition dropped');
+        state.b = true; state.a = 50;
+        assert.strictEqual(active(b.evaluate(R, 2 * MIN)).length, 0, 'first condition dropped');
+        state.a = 150;
+        assert.strictEqual(active(b.evaluate(R, 3 * MIN)).length, 1, 'both hold again');
+    });
+
+    it('names the condition that failed', function() {
+        // With one condition "condition-false" is enough; with several, which one is the
+        // whole question.
+        const b = createBayes(cfgOf({ rules: [twoConditions()] }));
+        const e = byId(b.evaluate(stateOf({ a: 150, b: false }), 0), 'and');
+        assert.strictEqual(e.status, 'condition-false');
+        assert.strictEqual(e.failedStep, 2);
+        assert.strictEqual(byId(b.evaluate(stateOf({ a: 50, b: true }), 0), 'and').failedStep, 1);
+    });
+
+    it('contributes nothing before it holds, and applies its full weight when it does', function() {
+        const b = createBayes(cfgOf({ rules: [twoConditions()] }));
+        assert.ok(Math.abs(b.evaluate(stateOf({ a: 50, b: true }), 0).p - 0.2) < 1e-12);
+        const on = b.evaluate(stateOf({ a: 150, b: true }), 0);
+        assert.ok(Math.abs(byId(on, 'and').share - 73.8) < 0.5, 'one strong weight, not two');
+    });
+
+    it('accepts isOrBecomes as a condition — it has nothing to wait for here', function() {
+        // The live rule that prompted this: a time window plus a level, the second saved as
+        // "now or soon" from when it was written as a sequence.
+        const b = createBayes(cfgOf({ rules: [{ id: 'r', lr: 10, halfLifeMs: null, steps: [
+            step('is', { thing: 'a' }),
+            step('isOrBecomes', { thing: 'b' })
+        ]}]}));
+        assert.strictEqual(active(b.evaluate(stateOf({ a: true, b: true }), 0)).length, 1);
+        assert.strictEqual(active(b.evaluate(stateOf({ a: true, b: false }), 0)).length, 0);
+    });
+
+    it('does not drive the sequence machinery', function() {
+        // handleEvent must leave an all-condition rule alone; an FSM entry for it would be
+        // state that nothing ever clears.
+        const b = createBayes(cfgOf({ rules: [twoConditions()] }));
+        b.handleEvent(hit('and', 0), true, 0);
+        assert.deepStrictEqual(b.serialize().fsm, {});
+    });
+
+    it('reports a rule that opens with a condition but waits for an event as never-fires', function() {
+        // Still unreachable, and now it says so instead of sitting at "armed" looking idle.
+        const b = createBayes(cfgOf({ rules: [{ id: 'dead', lr: 10, halfLifeMs: null, steps: [
+            step('is', { thing: 'a' }),
+            step('becomes', { thing: 'b' })
+        ]}]}));
+        const e = byId(b.evaluate(stateOf({ a: true, b: true }), 0), 'dead');
+        assert.strictEqual(e.status, 'never-fires');
+        assert.strictEqual(e.share, 0);
+
+        // A sequence that opens with an event is fine and stays armed.
+        const ok = createBayes(cfgOf({ rules: [arrivalRule('arr', 10)] }));
+        assert.strictEqual(byId(ok.evaluate(noState, 0), 'arr').status, 'armed');
+    });
+});

--- a/test/bayes.test.js
+++ b/test/bayes.test.js
@@ -8,6 +8,13 @@ const HOUR = 60 * MIN;
 
 // ---- helpers ----------------------------------------------------------------
 
+// evaluate() now reports every rule once, with a status, instead of an activeRules list and a
+// terms list. These ask the same two questions of the new shape: which rules hold a weight
+// right now, and which are carrying a decaying one.
+const active = r => r.rules.filter(x => x.status === 'contributing');
+const fading = r => r.rules.filter(x => x.status === 'fading' || x.status === 'injected');
+const byId   = (r, id) => r.rules.find(x => x.id === id);
+
 function cfgOf(overrides) {
     return Object.assign({
         prior: 0.2, pOn: 0.85, pOff: 0.30, clamp: 6, halfLifeMs: 20 * MIN,
@@ -183,13 +190,13 @@ describe('certain terms', function() {
         b.handleEvent(hit('arr', 0), true, 0);
         b.handleEvent(hit('arr', 0), false, MIN);
         b.handleEvent(hit('arr', 1), true, 1.5 * MIN);
-        assert.strictEqual(b.evaluate(noState, 2 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 2 * MIN)).length, 1);
         // Exit (certain false) fires — the positive term is cleared, not fought.
         b.handleEvent(hit('exit', 0), true, 3 * MIN);
         b.handleEvent(hit('exit', 0), false, 4 * MIN);
         b.handleEvent(hit('exit', 1), true, 4.5 * MIN);
         const r = b.evaluate(noState, 5 * MIN);
-        assert.deepStrictEqual(r.terms.map(t => t.ruleId), ['exit']);
+        assert.deepStrictEqual(fading(r).map(t => t.id), ['exit']);
         assert.ok(r.p < 0.05);
     });
 
@@ -199,13 +206,13 @@ describe('certain terms', function() {
         b.handleEvent(hit('exit', 0), true, 0);
         b.handleEvent(hit('exit', 0), false, MIN);
         b.handleEvent(hit('exit', 1), true, 1.5 * MIN);
-        assert.strictEqual(b.evaluate(noState, 2 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 2 * MIN)).length, 1);
         // Coming back: a mere moderate arrival invalidates the certain statement.
         b.handleEvent(hit('arr', 0), true, 10 * MIN);
         b.handleEvent(hit('arr', 0), false, 11 * MIN);
         b.handleEvent(hit('arr', 1), true, 11.5 * MIN);
         const r = b.evaluate(noState, 12 * MIN);
-        assert.deepStrictEqual(r.terms.map(t => t.ruleId), ['arr']);
+        assert.deepStrictEqual(fading(r).map(t => t.id), ['arr']);
         assert.ok(r.p > 0.2);
     });
 
@@ -217,7 +224,7 @@ describe('certain terms', function() {
         b.handleEvent(hit('down', 0), true, 3 * MIN);
         b.handleEvent(hit('down', 0), false, 4 * MIN);
         b.handleEvent(hit('down', 1), true, 4.5 * MIN);
-        assert.strictEqual(b.evaluate(noState, 5 * MIN).terms.length, 2);
+        assert.strictEqual(fading(b.evaluate(noState, 5 * MIN)).length, 2);
     });
 });
 
@@ -248,7 +255,7 @@ describe('momentary rules decay', function() {
         b.handleEvent(hit('a', 0), false, 0.5 * MIN);
         b.handleEvent(hit('a', 1), true, MIN);
         b.tick(40 * MIN);
-        assert.strictEqual(b.evaluate(noState, 40 * MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, 40 * MIN)).length, 0);
     });
 });
 
@@ -260,13 +267,13 @@ describe('step sequences', function() {
         b.handleEvent(hit('arr', 0), true, 0);
         b.handleEvent(hit('arr', 0), false, MIN);            // cycle ok (≤ 3 min)
         b.handleEvent(hit('arr', 1), true, 2 * MIN);          // within 2 min window
-        assert.strictEqual(b.evaluate(noState, 2 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 2 * MIN)).length, 1);
 
         const slow = createBayes(cfgOf({ rules: [arrivalRule('arr', 30)] }));
         slow.handleEvent(hit('arr', 0), true, 0);
         slow.handleEvent(hit('arr', 0), false, 4 * MIN);      // > cycleMax
         slow.handleEvent(hit('arr', 1), true, 4.5 * MIN);
-        assert.strictEqual(slow.evaluate(noState, 5 * MIN).terms.length, 0);
+        assert.strictEqual(fading(slow.evaluate(noState, 5 * MIN)).length, 0);
     });
 
     it('overlap: an edge during the previous step counts at its completion', function() {
@@ -274,7 +281,7 @@ describe('step sequences', function() {
         b.handleEvent(hit('arr', 0), true, 0);                // door opens
         b.handleEvent(hit('arr', 1), true, 0.5 * MIN);        // motion while open
         b.handleEvent(hit('arr', 0), false, MIN);             // door closes — fires here
-        assert.strictEqual(b.evaluate(noState, MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, MIN)).length, 1);
     });
 
     it('an edge before arming never counts', function() {
@@ -282,11 +289,11 @@ describe('step sequences', function() {
         b.handleEvent(hit('arr', 1), true, 0);                // motion before the door ever opens
         b.handleEvent(hit('arr', 0), true, 5 * MIN);
         b.handleEvent(hit('arr', 0), false, 6 * MIN);
-        assert.strictEqual(b.evaluate(noState, 6 * MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, 6 * MIN)).length, 0);
         // …but fresh motion within the window still confirms
         b.handleEvent(hit('arr', 1), false, 6.5 * MIN);
         b.handleEvent(hit('arr', 1), true, 7 * MIN);
-        assert.strictEqual(b.evaluate(noState, 7 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 7 * MIN)).length, 1);
     });
 
     it('a three-step rule completes in order and not out of order', function() {
@@ -300,13 +307,13 @@ describe('step sequences', function() {
         b.handleEvent(hit('r3', 1), true, MIN);               // door opens
         b.handleEvent(hit('r3', 1), false, 2 * MIN);          // door closes
         b.handleEvent(hit('r3', 2), true, 3 * MIN);           // motion
-        assert.strictEqual(b.evaluate(noState, 3 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 3 * MIN)).length, 1);
 
         const wrong = createBayes(cfgOf({ rules: [rule] }));
         wrong.handleEvent(hit('r3', 1), true, 0);             // door first — ignored at step 0
         wrong.handleEvent(hit('r3', 1), false, MIN);
         wrong.handleEvent(hit('r3', 2), true, 1.5 * MIN);
-        assert.strictEqual(wrong.evaluate(noState, 2 * MIN).terms.length, 0);
+        assert.strictEqual(fading(wrong.evaluate(noState, 2 * MIN)).length, 0);
     });
 
     it('timeout between steps resets the sequence; tick also cleans up', function() {
@@ -314,14 +321,14 @@ describe('step sequences', function() {
         b.handleEvent(hit('arr', 0), true, 0);
         b.handleEvent(hit('arr', 0), false, MIN);             // pending, window 2 min
         b.handleEvent(hit('arr', 1), true, 5 * MIN);          // too late
-        assert.strictEqual(b.evaluate(noState, 5 * MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, 5 * MIN)).length, 0);
 
         const t = createBayes(cfgOf({ rules: [arrivalRule('arr', 30)] }));
         t.handleEvent(hit('arr', 0), true, 0);                // door opens, never closes
         t.tick(10 * MIN);                                     // stale opening dropped
         t.handleEvent(hit('arr', 0), false, 10.5 * MIN);      // close without tracked open
         t.handleEvent(hit('arr', 1), true, 11 * MIN);
-        assert.strictEqual(t.evaluate(noState, 11 * MIN).terms.length, 0);
+        assert.strictEqual(fading(t.evaluate(noState, 11 * MIN)).length, 0);
     });
 
     it('no rising edge on step 0 means nothing ever arms (exit protection)', function() {
@@ -331,7 +338,7 @@ describe('step sequences', function() {
         // Phone goes true→false is a falling edge on "is true" — never arms.
         b.handleEvent(hit('r', 0), false, 0);
         b.handleEvent(hit('r', 1), true, MIN);
-        assert.strictEqual(b.evaluate(noState, MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, MIN)).length, 0);
     });
 
     it('a level check is answered when the previous step completes, whenever it turned true', function() {
@@ -345,7 +352,7 @@ describe('step sequences', function() {
         const b = createBayes(cfgOf({ rules: [rule] }));
         b.handleEvent(hit('arr', 0), true, 60 * MIN, stateOf(state));      // door opens
         b.handleEvent(hit('arr', 0), false, 61 * MIN, stateOf(state));     // closes → level check
-        assert.strictEqual(b.evaluate(noState, 61 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 61 * MIN)).length, 1);
     });
 
     it('a failing level check aborts the sequence', function() {
@@ -357,12 +364,12 @@ describe('step sequences', function() {
         const b = createBayes(cfgOf({ rules: [rule] }));
         b.handleEvent(hit('arr', 0), true, 0, stateOf(state));
         b.handleEvent(hit('arr', 0), false, MIN, stateOf(state));
-        assert.strictEqual(b.evaluate(noState, MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, MIN)).length, 0);
         // …and the sequence is reset, so the next real cycle still works.
         state.phone = true;
         b.handleEvent(hit('arr', 0), true, 10 * MIN, stateOf(state));
         b.handleEvent(hit('arr', 0), false, 11 * MIN, stateOf(state));
-        assert.strictEqual(b.evaluate(noState, 11 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 11 * MIN)).length, 1);
     });
 
     it('"is or becomes" accepts a condition that already holds', function() {
@@ -374,7 +381,7 @@ describe('step sequences', function() {
         const b = createBayes(cfgOf({ rules: [rule] }));
         b.handleEvent(hit('arr', 0), true, 0, stateOf(state));
         b.handleEvent(hit('arr', 0), false, MIN, stateOf(state));
-        assert.strictEqual(b.evaluate(noState, MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, MIN)).length, 1);
     });
 
     it('"is or becomes" waits for a late sensor instead of aborting', function() {
@@ -386,11 +393,11 @@ describe('step sequences', function() {
         const b = createBayes(cfgOf({ rules: [rule] }));
         b.handleEvent(hit('arr', 0), true, 0, stateOf(state));
         b.handleEvent(hit('arr', 0), false, MIN, stateOf(state));
-        assert.strictEqual(b.evaluate(noState, MIN).terms.length, 0);   // pending, not aborted
+        assert.strictEqual(fading(b.evaluate(noState, MIN)).length, 0);   // pending, not aborted
 
         state.phone = true;
         b.handleEvent(hit('arr', 1), true, 2 * MIN, stateOf(state));    // arrives inside the window
-        assert.strictEqual(b.evaluate(noState, 2 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 2 * MIN)).length, 1);
     });
 
     it('"is or becomes" still times out when the sensor never reports', function() {
@@ -404,7 +411,7 @@ describe('step sequences', function() {
         b.handleEvent(hit('arr', 0), false, MIN, stateOf(state));
         state.phone = true;
         b.handleEvent(hit('arr', 1), true, 10 * MIN, stateOf(state));    // far too late
-        assert.strictEqual(b.evaluate(noState, 10 * MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, 10 * MIN)).length, 0);
     });
 
     it('"now or soon" completes on a later tick when a polled source turns true', function() {
@@ -418,11 +425,11 @@ describe('step sequences', function() {
         const b = createBayes(cfgOf({ rules: [rule] }));
         b.handleEvent(hit('r', 0), true, 0, stateOf(state));
         b.handleEvent(hit('r', 0), false, MIN, stateOf(state));      // pending, level still false
-        assert.strictEqual(b.evaluate(noState, MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, MIN)).length, 0);
 
         state.flowvar = true;                                         // changes with no event
         b.tick(3 * MIN, stateOf(state));
-        assert.strictEqual(b.evaluate(noState, 3 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 3 * MIN)).length, 1);
     });
 
     it('a polled "now or soon" still times out if it never turns true', function() {
@@ -437,7 +444,7 @@ describe('step sequences', function() {
         b.tick(10 * MIN, stateOf(state));                             // window long gone
         state.flowvar = true;
         b.tick(11 * MIN, stateOf(state));
-        assert.strictEqual(b.evaluate(noState, 11 * MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, 11 * MIN)).length, 0);
     });
 
     it('a tick-completed step cascades into a following condition step', function() {
@@ -452,7 +459,7 @@ describe('step sequences', function() {
         b.handleEvent(hit('r', 0), false, MIN, stateOf(state));
         state.flowvar = true;
         b.tick(2 * MIN, stateOf(state));
-        assert.strictEqual(b.evaluate(noState, 2 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 2 * MIN)).length, 1);
     });
 
     it('tick without a resolver leaves pending steps alone', function() {
@@ -464,7 +471,7 @@ describe('step sequences', function() {
         b.handleEvent(hit('r', 0), true, 0, stateOf({ flowvar: true }));
         b.handleEvent(hit('r', 0), false, MIN, stateOf({ flowvar: false }));
         b.tick(2 * MIN);                                              // no resolver passed
-        assert.strictEqual(b.evaluate(noState, 2 * MIN).terms.length, 0);
+        assert.strictEqual(fading(b.evaluate(noState, 2 * MIN)).length, 0);
     });
 
     it('level checks chain: door cycle, then motion, and the phone is here', function() {
@@ -478,7 +485,7 @@ describe('step sequences', function() {
         b.handleEvent(hit('arr', 0), true, 0, stateOf(state));
         b.handleEvent(hit('arr', 0), false, MIN, stateOf(state));
         b.handleEvent(hit('arr', 1), true, 1.5 * MIN, stateOf(state));
-        assert.strictEqual(b.evaluate(noState, 2 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 2 * MIN)).length, 1);
     });
 
     it('repeated identical reports count once (edge dedupe)', function() {
@@ -488,7 +495,7 @@ describe('step sequences', function() {
         b.handleEvent(hit('arr', 0), false, MIN);
         b.handleEvent(hit('arr', 1), true, 1.5 * MIN);
         b.handleEvent(hit('arr', 1), true, 1.6 * MIN);        // repeat
-        assert.strictEqual(b.evaluate(noState, 2 * MIN).terms.length, 1);
+        assert.strictEqual(fading(b.evaluate(noState, 2 * MIN)).length, 1);
     });
 });
 
@@ -588,7 +595,7 @@ describe('scaled rule weight', function() {
         const mid = at(40);
         assert.ok(mid.p > 0.2 && mid.p < 0.85, 'halfway dry is partial evidence');
         assert.ok(Math.abs(at(59).p - 0.2) < 0.05, 'nearly wet contributes almost nothing');
-        assert.strictEqual(at(70).activeRules.length, 0, 'above the condition it is not active at all');
+        assert.strictEqual(active(at(70)).length, 0, 'above the condition it is not active at all');
     });
 
     it('a negative endpoint share pushes the estimate down', function() {
@@ -602,7 +609,7 @@ describe('scaled rule weight', function() {
     it('an unusable reading makes a scaled rule contribute nothing', function() {
         const b = createBayes(cfgOf({ rules: [soil()] }));
         const r = b.evaluate(stateOf({ soil: 'n/a' }), 0);
-        assert.strictEqual(r.activeRules.length, 0);
+        assert.strictEqual(active(r).length, 0);
         assert.ok(Math.abs(r.p - 0.2) < 1e-12);
     });
 
@@ -629,7 +636,7 @@ describe('scaled rule weight', function() {
         const b = createBayes(cfgOf({ rules: [strongSoil, against] }));
         b.handleEvent(hit('sun', 0), true, 0, stateOf({ sun: true }));
         b.handleEvent(hit('soil', 0), 20, MIN, stateOf({ soil: 20 }));
-        assert.strictEqual(b.evaluate(noState, MIN).terms.length, 2, 'both terms coexist');
+        assert.strictEqual(fading(b.evaluate(noState, MIN)).length, 2, 'both terms coexist');
     });
 
     it('reference irrigation set: dryness can override the sun', function() {
@@ -680,10 +687,10 @@ describe('persistence and input', function() {
         ] }));
         const state = { x: true, y: true };
         const r = b.evaluate(stateOf(state), 0);
-        assert.strictEqual(r.activeRules.length, 2);
+        assert.strictEqual(active(r).length, 2);
         assert.ok(r.p > 0.9);                      // both contribute, not just one
         state.y = false;
-        assert.strictEqual(b.evaluate(stateOf(state), 0).activeRules.length, 1);
+        assert.strictEqual(active(b.evaluate(stateOf(state), 0)).length, 1);
     });
 
     it('restore starts the maxHold clock when a held-on state has none', function() {
@@ -736,7 +743,7 @@ describe('persistence and input', function() {
             b.restore(junk);
             const r = b.evaluate(noState, 0);
             assert.strictEqual(r.binary, false);
-            assert.strictEqual(r.terms.length, 0);
+            assert.strictEqual(fading(r).length, 0);
         }
     });
 
@@ -750,7 +757,130 @@ describe('persistence and input', function() {
         assert.strictEqual(b.inject(1, null, 0), false);
         b.reset();
         const r = b.evaluate(noState, 0);
-        assert.strictEqual(r.terms.length, 0);
+        assert.strictEqual(fading(r).length, 0);
         assert.ok(Math.abs(r.p - 0.2) < 1e-12);
+    });
+});
+
+describe('snapshot report', function() {
+    // What output 2 carries. The estimate itself is tested above; this is about whether the
+    // report explains it — every rule accounted for, with a status saying why.
+
+    it('lists every configured rule exactly once, whatever its state', function() {
+        // The guard that matters: a rule must not fall out of the report because no branch
+        // claimed it. Four rules in four different states, four entries.
+        const b = createBayes(cfgOf({ rules: [
+            contRule('on',  10, { thing: 'a' }),
+            contRule('off', 10, { thing: 'b' }),
+            arrivalRule('seq', 3),
+            { id: 'scaled', lr: 1, halfLifeMs: null, scale: { fromValue: 0, fromShare: 1, toValue: 10, toShare: 0 },
+              steps: [step('is', { thing: 'c', operator: 'neq', value: '', valueType: 'str' })] }
+        ]}));
+        b.handleEvent(hit('seq', 0), true, 0);
+        b.handleEvent(hit('seq', 0), false, MIN);          // cycle done → parked on step 2
+        const r = b.evaluate(stateOf({ a: true, b: false, c: 'warm' }), MIN);
+
+        assert.strictEqual(r.rules.length, 4);
+        assert.deepStrictEqual(r.rules.map(x => x.id), ['on', 'off', 'seq', 'scaled']);
+        assert.strictEqual(byId(r, 'on').status, 'contributing');
+        assert.strictEqual(byId(r, 'off').status, 'condition-false');
+        assert.strictEqual(byId(r, 'seq').status, 'waiting');
+        assert.strictEqual(byId(r, 'scaled').status, 'no-value', 'condition holds but the reading is not a number');
+    });
+
+    it('reports what a rule reads, so a false condition can be seen rather than inferred', function() {
+        const b = createBayes(cfgOf({ rules: [contRule('temp', 10, { thing: 'a', operator: 'gt', value: '25', valueType: 'num' })] }));
+        const r = b.evaluate(stateOf({ a: 23.4 }), 0);
+        assert.strictEqual(byId(r, 'temp').status, 'condition-false');
+        assert.strictEqual(byId(r, 'temp').value, 23.4);
+    });
+
+    it('says no-value, without a value, when the source cannot be read at all', function() {
+        const b = createBayes(cfgOf({ rules: [contRule('gone', 10, { thing: 'missing' })] }));
+        const r = b.evaluate(stateOf({}), 0);
+        assert.strictEqual(byId(r, 'gone').status, 'no-value');
+        assert.ok(!('value' in byId(r, 'gone')), 'nothing read, so nothing reported');
+    });
+
+    it('shares agree with the estimate they explain', function() {
+        // Log-odds are additive and a share is just a rescaling of one, so the contributing
+        // shares have to sum to the total. If they ever drift the report is lying.
+        const b = createBayes(cfgOf({ rules: [
+            contRule('a', 10, { thing: 'a' }),
+            contRule('b', 3,  { thing: 'b' })
+        ]}));
+        const r = b.evaluate(stateOf({ a: true, b: true }), 0);
+        const sum = active(r).reduce((t, x) => t + x.share, 0);
+        assert.ok(Math.abs(sum - r.share) < 0.2, sum + ' vs ' + r.share);
+        // 'strong' is the 74 % of the editor's scale.
+        assert.ok(Math.abs(byId(r, 'a').share - 73.8) < 0.5);
+    });
+
+    it('a rule at 100 % is exactly the one that reaches the threshold alone', function() {
+        // The same boundary the editor's summary draws: at 100 % the estimate touches pOn.
+        const lr = Math.exp(scale.requiredGain(0.2, 0.85));
+        const b = createBayes(cfgOf({ rules: [contRule('alone', lr, { thing: 'a' })] }));
+        const r = b.evaluate(stateOf({ a: true }), 0);
+        assert.ok(Math.abs(byId(r, 'alone').share - 100) < 0.2);
+        assert.ok(Math.abs(r.p - 0.85) < 1e-6);
+        assert.strictEqual(r.binary, true);
+    });
+
+    it('a momentary rule reads as fading, with its age and half-life', function() {
+        const b = createBayes(cfgOf({ rules: [arrivalRule('arr', 10)] }));
+        b.handleEvent(hit('arr', 0), true, 0);
+        b.handleEvent(hit('arr', 0), false, MIN);
+        b.handleEvent(hit('arr', 1), true, 1.5 * MIN);      // fires
+
+        const at = b.evaluate(noState, 1.5 * MIN);
+        assert.strictEqual(byId(at, 'arr').status, 'fading');
+        assert.strictEqual(byId(at, 'arr').age, 0);
+        assert.strictEqual(byId(at, 'arr').halfLife, 20 * 60, 'the node default, in seconds');
+
+        // A half-life later the contribution has halved, and so has the share.
+        const later = b.evaluate(noState, 21.5 * MIN);
+        assert.strictEqual(byId(later, 'arr').age, 20 * 60);
+        assert.ok(Math.abs(byId(later, 'arr').share - byId(at, 'arr').share / 2) < 0.5);
+    });
+
+    it('a waiting sequence says where it is and how long it has', function() {
+        const b = createBayes(cfgOf({ rules: [arrivalRule('arr', 10)] }));
+        b.handleEvent(hit('arr', 0), true, 0);
+        b.handleEvent(hit('arr', 0), false, MIN);          // step 1 done, window is 2 min
+
+        const e = byId(b.evaluate(noState, 1.5 * MIN), 'arr');
+        assert.strictEqual(e.status, 'waiting');
+        assert.strictEqual(e.step, 2);
+        assert.strictEqual(e.steps, 2);
+        assert.strictEqual(e.deadline, 90, 'seconds left of the 2-minute window');
+
+        // Before anything arms it, the same rule is idle rather than waiting.
+        const fresh = createBayes(cfgOf({ rules: [arrivalRule('arr', 10)] }));
+        assert.strictEqual(byId(fresh.evaluate(noState, 0), 'arr').status, 'armed');
+    });
+
+    it('injected evidence gets its own entry and leaves when it decays', function() {
+        const b = createBayes(cfgOf({ rules: [contRule('a', 10, { thing: 'a' })] }));
+        b.inject(30, 10 * MIN, 0);
+        const r = b.evaluate(stateOf({ a: false }), 0);
+        assert.strictEqual(r.rules.length, 2, 'the configured rule plus the injection');
+        assert.strictEqual(byId(r, 'injected').status, 'injected');
+        assert.ok(byId(r, 'injected').share > 0);
+
+        // Once pruned it is gone from the report, not left at zero.
+        b.tick(3 * HOUR, noState);
+        const after = b.evaluate(stateOf({ a: false }), 3 * HOUR);
+        assert.strictEqual(after.rules.length, 1);
+        assert.strictEqual(byId(after, 'injected'), undefined);
+    });
+
+    it('carries the label the node attached, falling back to the id', function() {
+        const b = createBayes(cfgOf({ rules: [
+            Object.assign(contRule('a', 10, { thing: 'a' }), { label: 'While Kontor · Temperature is true' }),
+            contRule('b', 10, { thing: 'b' })
+        ]}));
+        const r = b.evaluate(stateOf({ a: true, b: true }), 0);
+        assert.strictEqual(byId(r, 'a').label, 'While Kontor · Temperature is true');
+        assert.strictEqual(byId(r, 'b').label, 'b', 'unlabelled rules stay identifiable');
     });
 });

--- a/test/bayes.test.js
+++ b/test/bayes.test.js
@@ -959,3 +959,36 @@ describe('multi-condition rules', function() {
         assert.strictEqual(byId(ok.evaluate(noState, 0), 'arr').status, 'armed');
     });
 });
+
+describe('unusable operator and value pairings', function() {
+    // The editor now offers only 're' for a regex comparison, but a rule saved before that
+    // can pair it with a plain string — and COMPARE.regex calls b.test, which a string does
+    // not have. One bad rule must not take the whole evaluation down with it.
+    it('a regex operator against a string value does not throw', function() {
+        const b = createBayes(cfgOf({ rules: [
+            { id: 'bad', lr: 3, halfLifeMs: null,
+              steps: [step('is', { thing: 'a', operator: 'regex', value: '^on$', valueType: 'str' })] },
+            { id: 'good', lr: 10, halfLifeMs: null, steps: [step('is', { thing: 'b' })] }
+        ]}));
+        const r = b.evaluate(stateOf({ a: 'on', b: true }), 0);
+        assert.strictEqual(byId(r, 'bad').status, 'condition-false', 'unevaluable is not a match');
+        assert.strictEqual(byId(r, 'good').status, 'contributing', 'and the other rules still run');
+    });
+
+    it('a regex operator against a real regex still matches', function() {
+        const b = createBayes(cfgOf({ rules: [
+            { id: 'r', lr: 10, halfLifeMs: null,
+              steps: [step('is', { thing: 'a', operator: 'regex', value: '^on$', valueType: 're' })] }
+        ]}));
+        assert.strictEqual(byId(b.evaluate(stateOf({ a: 'on' }), 0), 'r').status, 'contributing');
+        assert.strictEqual(byId(b.evaluate(stateOf({ a: 'off' }), 0), 'r').status, 'condition-false');
+    });
+
+    it('an unparseable value leaves the rule inactive rather than throwing', function() {
+        const b = createBayes(cfgOf({ rules: [
+            { id: 'j', lr: 3, halfLifeMs: null,
+              steps: [step('is', { thing: 'a', operator: 'eq', value: '{not json', valueType: 'json' })] }
+        ]}));
+        assert.strictEqual(byId(b.evaluate(stateOf({ a: 'x' }), 0), 'j').status, 'condition-false');
+    });
+});

--- a/test/bayesLabel.test.js
+++ b/test/bayesLabel.test.js
@@ -1,0 +1,103 @@
+'use strict';
+const assert = require('node:assert');
+const bl = require('../resources/bayes-label');
+
+// Steps as core/bayes.js normalises them, with the names it resolves alongside.
+const step = (o) => Object.assign({ src: 'thing', pattern: 'is', operator: 'true' }, o);
+const named = (source) => ({ source });
+
+describe('bayes-label describeStep', function () {
+    it('reads a level check on a thing item', function () {
+        assert.strictEqual(
+            bl.describeStep(step({ operator: 'gt', value: '25', valueType: 'num' }),
+                            named('Kontor Sensor · Temperature'), 0, true),
+            'While Kontor Sensor · Temperature > 25');
+    });
+
+    it('drops the comparison value for the unary operators', function () {
+        // "is true 25" would be nonsense; the operator has already said everything.
+        assert.strictEqual(
+            bl.describeStep(step({ operator: 'true', value: '25' }), named('Hall Rörelse · Motion'), 0, true),
+            'While Hall Rörelse · Motion is true');
+        assert.strictEqual(
+            bl.describeStep(step({ operator: 'false' }), named('Hall Rörelse · Motion'), 0, true),
+            'While Hall Rörelse · Motion is false');
+    });
+
+    it('names the pattern when the step is an event rather than a condition', function () {
+        assert.strictEqual(
+            bl.describeStep(step({ pattern: 'becomes' }), named('Ytterdörr · Contact'), 0, false),
+            'When Ytterdörr · Contact is true on change');
+        assert.strictEqual(
+            bl.describeStep(step({ pattern: 'cycle' }), named('Ytterdörr · Contact'), 0, false),
+            'When Ytterdörr · Contact is true on a full cycle');
+    });
+
+    it('words a time window as inside or outside', function () {
+        const w = step({ src: 'time', operator: 'true' });
+        assert.strictEqual(bl.describeStep(w, { window: '22:00–06:00, Mo–Fr' }, 0, true),
+            'While 22:00–06:00, Mo–Fr is inside');
+        assert.strictEqual(bl.describeStep(step({ src: 'time', operator: 'false' }),
+            { window: '22:00–06:00, Mo–Fr' }, 0, true),
+            'While 22:00–06:00, Mo–Fr is outside');
+    });
+
+    it('falls back to whatever the step carries when a name cannot be resolved', function () {
+        // A label is never empty: a deleted thing still has to be recognisable in the snapshot.
+        assert.strictEqual(bl.describeStep(step({ thing: 'abc123' }), null, 0, true),
+            'While abc123 is true');
+        assert.strictEqual(bl.describeStep(step({ src: 'flow', prop: 'guestMode' }), null, 0, true),
+            'While guestMode is true');
+        assert.strictEqual(bl.describeStep(step({ src: 'group', group: 'g1' }), null, 0, true),
+            'While g1 is true');
+    });
+
+    it('picks the lead word from position and pattern', function () {
+        const s = step({});
+        assert.strictEqual(bl.describeStep(s, named('X'), 0, true).split(' ')[0], 'While');
+        assert.strictEqual(bl.describeStep(s, named('X'), 0, false).split(' ')[0], 'When');
+        assert.strictEqual(bl.describeStep(s, named('X'), 1, false).split(' ')[0], 'and');
+        assert.strictEqual(
+            bl.describeStep(step({ pattern: 'isOrBecomes' }), named('X'), 1, false).split(' ')[0], 'and');
+        assert.strictEqual(
+            bl.describeStep(step({ pattern: 'becomes' }), named('X'), 1, false).split(' ')[0], 'then');
+        assert.strictEqual(
+            bl.describeStep(step({ pattern: 'cycle' }), named('X'), 1, false).split(' ')[0], 'then');
+    });
+
+    it('returns an empty string rather than throwing on a missing step', function () {
+        assert.strictEqual(bl.describeStep(undefined, named('X'), 0, true), '');
+    });
+});
+
+describe('bayes-label describeRule', function () {
+    it('reads a single level check as one clause', function () {
+        const rule = { steps: [step({ operator: 'gt', value: '25' })] };
+        assert.strictEqual(bl.describeRule(rule, [named('Kontor Sensor · Temperature')]),
+            'While Kontor Sensor · Temperature > 25');
+    });
+
+    it('reads a sequence end to end', function () {
+        const rule = { steps: [
+            step({ pattern: 'cycle' }),
+            step({ pattern: 'is', operator: 'true' })
+        ]};
+        assert.strictEqual(
+            bl.describeRule(rule, [named('Ytterdörr · Contact'), named('Hall Rörelse · Motion')]),
+            'When Ytterdörr · Contact is true on a full cycle and Hall Rörelse · Motion is true');
+    });
+
+    it('calls only a lone level check continuous', function () {
+        // The same test the estimator uses to decide whether a rule holds a weight or fires
+        // one, so "While" in a label means exactly "this rule holds a weight".
+        assert.strictEqual(bl.isContinuous({ steps: [step({ pattern: 'is' })] }), true);
+        assert.strictEqual(bl.isContinuous({ steps: [step({ pattern: 'becomes' })] }), false);
+        assert.strictEqual(bl.isContinuous({ steps: [step({}), step({})] }), false);
+        assert.strictEqual(bl.isContinuous(null), false);
+    });
+
+    it('is empty for a rule with no steps', function () {
+        assert.strictEqual(bl.describeRule({ steps: [] }, []), '');
+        assert.strictEqual(bl.describeRule(null, null), '');
+    });
+});

--- a/test/bayesLabel.test.js
+++ b/test/bayesLabel.test.js
@@ -87,13 +87,28 @@ describe('bayes-label describeRule', function () {
             'When Ytterdörr · Contact is true on a full cycle and Hall Rörelse · Motion is true');
     });
 
-    it('calls only a lone level check continuous', function () {
+    it('calls a rule continuous when every step is a condition', function () {
         // The same test the estimator uses to decide whether a rule holds a weight or fires
         // one, so "While" in a label means exactly "this rule holds a weight".
         assert.strictEqual(bl.isContinuous({ steps: [step({ pattern: 'is' })] }), true);
+        assert.strictEqual(bl.isContinuous({ steps: [step({ pattern: 'is' }), step({ pattern: 'is' })] }), true,
+            'two conditions are an AND, not a sequence');
+        assert.strictEqual(bl.isContinuous({ steps: [step({ pattern: 'is' }), step({ pattern: 'isOrBecomes' })] }), true);
         assert.strictEqual(bl.isContinuous({ steps: [step({ pattern: 'becomes' })] }), false);
-        assert.strictEqual(bl.isContinuous({ steps: [step({}), step({})] }), false);
+        assert.strictEqual(bl.isContinuous({ steps: [step({ pattern: 'is' }), step({ pattern: 'becomes' })] }), false);
+        assert.strictEqual(bl.isContinuous({ steps: [] }), false);
         assert.strictEqual(bl.isContinuous(null), false);
+    });
+
+    it('reads a two-condition rule as one While clause', function () {
+        // The rule that prompted this: a time window and a level, both holding at once.
+        const rule = { steps: [
+            step({ src: 'time', operator: 'true' }),
+            step({ pattern: 'isOrBecomes', operator: 'gt', value: '100', valueType: 'num' })
+        ]};
+        assert.strictEqual(
+            bl.describeRule(rule, [{ window: '09:00–10:00, every day' }, named('Terrass Sensor · Lux')]),
+            'While 09:00–10:00, every day is inside and Terrass Sensor · Lux > 100');
     });
 
     it('is empty for a rule with no steps', function () {

--- a/test/halEditorHelpers.test.js
+++ b/test/halEditorHelpers.test.js
@@ -13,7 +13,7 @@ sandbox.self = sandbox;
 sandbox.window = sandbox;
 vm.createContext(sandbox);
 vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'resources', 'hal.js'), 'utf8'), sandbox);
-const { halNumericOperator, halShouldDefaultNumeric } = sandbox;
+const { halNumericOperator } = sandbox;
 
 describe('hal.js halNumericOperator', function () {
     it('claims the comparisons that can only mean a number', function () {
@@ -28,43 +28,5 @@ describe('hal.js halNumericOperator', function () {
         for (const op of ['eq', 'neq', 'cont', 'regex', 'true', 'false', undefined, '']) {
             assert.strictEqual(halNumericOperator(op), false, String(op));
         }
-    });
-});
-
-describe('hal.js halShouldDefaultNumeric', function () {
-    it('switches an empty field on a numeric comparison', function () {
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', ''), true);
-        assert.strictEqual(halShouldDefaultNumeric('lte', 'str', undefined), true);
-    });
-
-    it('switches a field that already holds a number', function () {
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', '100'), true);
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', ' 21.5 '), true);
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', '-3'), true);
-    });
-
-    it('leaves text alone — it was typed on purpose', function () {
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', 'warm'), false);
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', '10 lux'), false);
-    });
-
-    it('never overrides a type the user chose', function () {
-        // A flow/msg reference or an explicit type is a decision; only the default string
-        // type is treated as "not yet decided".
-        for (const t of ['num', 'flow', 'global', 'msg', 'env', 're', 'bool', 'json']) {
-            assert.strictEqual(halShouldDefaultNumeric('gt', t, ''), false, t);
-        }
-    });
-
-    it('does nothing for operators that do not imply a number', function () {
-        assert.strictEqual(halShouldDefaultNumeric('eq', 'str', '100'), false);
-        assert.strictEqual(halShouldDefaultNumeric('cont', 'str', '100'), false);
-        assert.strictEqual(halShouldDefaultNumeric('true', 'str', ''), false);
-    });
-
-    it('does not mistake blank-ish or infinite input for a number', function () {
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', '   '), true, 'still empty');
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', 'Infinity'), false);
-        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', 'NaN'), false);
     });
 });

--- a/test/halEditorHelpers.test.js
+++ b/test/halEditorHelpers.test.js
@@ -1,0 +1,70 @@
+'use strict';
+// resources/hal.js is a browser file loaded by the node editors, so it is run here in a
+// sandbox with a window rather than required. Only the pure decision helpers are exercised —
+// the DOM-walking ones need RED and an editor to mean anything.
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const sandbox = { console };
+sandbox.self = sandbox;
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(__dirname, '..', 'resources', 'hal.js'), 'utf8'), sandbox);
+const { halNumericOperator, halShouldDefaultNumeric } = sandbox;
+
+describe('hal.js halNumericOperator', function () {
+    it('claims the comparisons that can only mean a number', function () {
+        for (const op of ['lt', 'lte', 'gt', 'gte']) {
+            assert.strictEqual(halNumericOperator(op), true, op);
+        }
+    });
+
+    it('leaves the ambiguous ones alone', function () {
+        // eq/neq are as at home with a string as with a number, and the unary ones take no
+        // value at all — guessing for those would be guessing wrong half the time.
+        for (const op of ['eq', 'neq', 'cont', 'regex', 'true', 'false', undefined, '']) {
+            assert.strictEqual(halNumericOperator(op), false, String(op));
+        }
+    });
+});
+
+describe('hal.js halShouldDefaultNumeric', function () {
+    it('switches an empty field on a numeric comparison', function () {
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', ''), true);
+        assert.strictEqual(halShouldDefaultNumeric('lte', 'str', undefined), true);
+    });
+
+    it('switches a field that already holds a number', function () {
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', '100'), true);
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', ' 21.5 '), true);
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', '-3'), true);
+    });
+
+    it('leaves text alone — it was typed on purpose', function () {
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', 'warm'), false);
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', '10 lux'), false);
+    });
+
+    it('never overrides a type the user chose', function () {
+        // A flow/msg reference or an explicit type is a decision; only the default string
+        // type is treated as "not yet decided".
+        for (const t of ['num', 'flow', 'global', 'msg', 'env', 're', 'bool', 'json']) {
+            assert.strictEqual(halShouldDefaultNumeric('gt', t, ''), false, t);
+        }
+    });
+
+    it('does nothing for operators that do not imply a number', function () {
+        assert.strictEqual(halShouldDefaultNumeric('eq', 'str', '100'), false);
+        assert.strictEqual(halShouldDefaultNumeric('cont', 'str', '100'), false);
+        assert.strictEqual(halShouldDefaultNumeric('true', 'str', ''), false);
+    });
+
+    it('does not mistake blank-ish or infinite input for a number', function () {
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', '   '), true, 'still empty');
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', 'Infinity'), false);
+        assert.strictEqual(halShouldDefaultNumeric('gt', 'str', 'NaN'), false);
+    });
+});


### PR DESCRIPTION
Tuning a Bayes node meant reading a probability and guessing what produced it. The snapshot on
output 2 already carried the raw material — `activeRules`, `terms` and `fsm` — but not in a form
anyone could use: rules appeared as internal ids, contributions were in log-odds while the whole
editor speaks *share of the way to on* in percent, the three fields had to be cross-read against
each other, and **only contributing rules appeared at all**. The question while tuning is usually
why a rule is *not* firing, and nothing in the snapshot answered it.

## One `rules` array

The three fields are replaced by one array listing every configured rule, every time, with a
status saying which case it is in.

```json
{ "p": 0.86, "logOdds": 1.86, "share": 108.4, "binary": true, "held": false,
  "rules": [
    { "label": "While Hall Rörelse · Motion is true",
      "status": "contributing", "share": 73.8, "logOdds": 2.303, "value": true },
    { "label": "When Ytterdörr · Contact is true on a full cycle and Hall Rörelse · Motion is true",
      "status": "waiting", "step": 2, "steps": 2, "deadline": 47 },
    { "label": "While Kontor Sensor · Temperature > 25",
      "status": "condition-false", "value": 23.4 }
  ] }
```

`contributing`, `fading` (with age and half-life), `waiting` (with step and deadline), `armed`,
`condition-false` (with `failedStep`), `no-value`, `injected`, `never-fires`. Each entry carries
what its source reads right now, so a false condition can be seen rather than inferred.

Contributions are reported as **shares of the way from the prior to the on-threshold** — the unit
the rule bars and the summary already use, so what you tuned is what you read back. Log-odds are
additive, so the shares are too: the contributing ones sum to the snapshot's own `share`, pinned by
a test, because a report that does not add up is a report that lies.

The report is built in the same pass that computes the estimate, so a rule cannot be described as
contributing unless its weight really went into the log-odds.

Labels are derived from the steps and phrased as the editor phrases them. The phrasing lives in a
UMD module (`resources/bayes-label.js`) so the editor can adopt it later; name resolution stays in
the node, the only layer that can reach `RED.nodes`.

## A rule of only conditions is an AND

Found by using the report: a live rule sat at `armed` forever, and asking why exposed a real gap.

"While it is 09:00–10:00 **and** the terrace is above 100 lux" could not be expressed. Anything
with more than one step went to the sequence machinery, which is driven by edges — and a condition
is not an event, so the first step never completed. The editor warned about it, but the only way
out was to rewrite the rule as something that meant something else.

A rule whose steps are all conditions is now continuous: one weight that applies while every
condition holds at the same time. `isContinuous` grows from "a lone level check" to "every step is
a level check", and the label module and the editor follow, so such a rule reads "While A and B" in
all three places. A rule that opens with a condition but waits for an event later is still
unreachable and now says so as `never-fires` rather than sitting at `armed` looking merely idle.

The editor stops offering what such a step cannot use: in an AND there is no previous step to be
"soon" after, so later steps offer only "now". A step that is already a condition is narrowed with
a notice, since the behaviour is identical either way; an *event* after a leading condition is left
alone — that is a broken rule rather than an AND, and coercing it would quietly turn "then the door
opens" into "and the door is open".

## A crash on the way out

hal2Bayes has a `regex` operator but never forced the matching value type, and `COMPARE.regex`
calls `b.test` — so a rule saved as regex-against-a-string threw a `TypeError` out of `evaluate()`
and took the whole evaluation with it, every other rule included. Reachable from the editor until
now.

The value types are narrowed to what each operator can use, following what hal2Event and hal2Gate
already did rather than inventing a third behaviour. And `conditionMatches` now guards the
comparison as well as the conversion: a condition that cannot be evaluated has not matched, and its
neighbours still run.

## Testing

249 passing. The new ones cover every status, that every configured rule appears exactly once in
every state, that the shares sum to the total, the AND semantics at each edge, `never-fires`, and
the regex crash.

Verified against the running instance: labels rendered from the live configuration, the rule that
prompted this simulated through all four combinations of its two conditions, and `waiting` with a
counting-down deadline plus `fading` decaying per tick observed on a real node.
