### PR TITLE
hal2Bayes: shares toward the reachable threshold, and a persistence qualifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,11 +305,23 @@ slow to report, *now or soon* makes the step wait rather than fail. Only a step 
 
 Each rule pushes toward true or false with a word strength — **slight** (LR 1.5), **moderate**
 (3), **strong** (10), **decisive** (30), **certain** (400). The editor shows every rule as a
-*share of the way* from the prior to the on-threshold, and shares add exactly: 74 % + 35 % =
+*share of the way* from the prior to the threshold the node can actually cross, and shares add
+exactly: 74 % + 35 % =
 109 % turns the output on. This is also how shared sensors are disambiguated without any
 special logic: give the door/motion arrival rule a share too small to cross the line alone, so
 it only matters together with the node's own strong indicator — someone else arriving contributes
-35 % to this node and nothing happens. A **certain** rule overrides history: firing it clears
+35 % to this node and nothing happens.
+
+**A prior above the on-threshold is a supported configuration, and a useful one.** The node then
+rests *on* and rules push it off, which is how you say "assume the house is quiet until something
+says otherwise" — no rule has to argue the resting case, and silence is the answer rather than
+something to be reconstructed. Shares are then measured toward the off-threshold, since that is
+the only line the estimate can cross, and the editor's summary says so. The constraint to keep in
+mind is that the prior must be reachable in one hop by your strongest veto: at prior 0.93 with an
+off-threshold of 0.35, one **decisive** rule is 106 % of the way and just enough, while 0.95 would
+need **certain**.
+
+A **certain** rule overrides history: firing it clears
 opposing evidence, and a stored certain statement is cleared by any later contradicting rule.
 
 ### Weights that follow the reading

--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ Everything is a **rule**, built from steps. Each step names a source and a condi
 - **now** — a condition, true at that instant (*and…*)
 - **now or soon** — the same, but it waits for the condition until the window runs out; for
   sensors that report late (*and…*)
+- **for a while** — a condition that must have been continuously true for its own duration
+  before it counts. This is what separates a trip to the bathroom from getting up for the day:
+  the reading is identical at the moment it happens, and only time tells them apart. The clock
+  restarts whenever the condition drops, so a string of short absences never adds up to a long
+  one, and it survives a restart because the edge is persisted with the rest of the state
+  (*and…*)
 - **on change** — an event: the condition must actually turn true, being already true does
   not count (*then…*)
 - **on a full cycle** — a cycle: true and back to false within its limit, e.g. a door opening

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -120,6 +120,11 @@
             its window runs out; "soon" is exactly that <i>within N s</i>. Use it for sensors that
             report late. Only offered after the first step, since it needs a previous step to be soon
             after. Reads <i>and&hellip;</i></li>
+        <li><b>for a while</b> &mdash; a condition that must have been continuously true for its own
+            duration before it counts, set on the timing line. Separates a brief blip from a
+            settled state &mdash; a trip to the bathroom from getting up for the day &mdash; where
+            the reading itself is identical and only time tells them apart. The clock restarts
+            whenever the condition drops. Reads <i>and&hellip;</i></li>
         <li><b>on change</b> &mdash; an event: the condition must actually turn true, being already
             true does not count. Reads <i>then&hellip;</i></li>
         <li><b>on a full cycle</b> &mdash; a cycle: true and back to false within its limit, e.g. a
@@ -269,9 +274,9 @@
     (function() {
         var scale = window.hal2BayesScale;
         var btime = window.hal2BayesTime;
-        var PATTERNS = { is: 'now', isOrBecomes: 'now or soon',
+        var PATTERNS = { is: 'now', isOrBecomes: 'now or soon', held: 'for a while',
                          becomes: 'on change', cycle: 'on a full cycle' };
-        var ALL_PATTERNS = ['is', 'isOrBecomes', 'becomes', 'cycle'];
+        var ALL_PATTERNS = ['is', 'isOrBecomes', 'held', 'becomes', 'cycle'];
         // Rebuilds only when the option set actually differs, so a selection survives
         // every refresh. `keep` is what the value should be if it is still offered.
         function setPatternOptions(patSel, allowed, keep) {
@@ -396,7 +401,8 @@
                 }
 
                 function isCondition(st) {
-                    return !!st && (st.pattern === 'is' || st.pattern === 'isOrBecomes');
+                    return !!st && (st.pattern === 'is' || st.pattern === 'isOrBecomes' ||
+                                    st.pattern === 'held');
                 }
                 function isContinuous(rule) {
                     // A rule made only of level checks is the continuous case: one weight that
@@ -551,6 +557,16 @@
                     });
 
 
+                    // How long a "for a while" condition has to have held. Its own number
+                    // rather than the step window: the window bounds when a step may happen,
+                    // this bounds how long it must already have been happening.
+                    var holdSpan = $('<span/>', { class: "bs-hold-span" }).appendTo(timing);
+                    $('<span/>', { class: "bs-hold-sep" }).appendTo(holdSpan).text(' · ');
+                    $('<span/>').appendTo(holdSpan).text('has held for ');
+                    $('<input/>', { class: "bs-hold", type: "number", min: "1", step: "any", style: "width:55px;" })
+                        .appendTo(holdSpan).val(step.hold === undefined ? 600 : step.hold);
+                    $('<span/>').appendTo(holdSpan).text(' s');
+
                     var cycleSpan = $('<span/>', { class: "bs-cycle-span" }).appendTo(timing);
                     $('<span/>', { class: "bs-cycle-sep" }).appendTo(cycleSpan).text(' · ');
                     $('<span/>').appendTo(cycleSpan).text('on then off within ');
@@ -685,6 +701,7 @@
                             valueType: el.find('.bs-val').typedInput('type'),
                             pattern:  el.find('.bs-pattern option:selected').val(),
                             cycleMax: el.find('.bs-cyclemax').val(),
+                            hold:     el.find('.bs-hold').val(),
                             window:   el.find('.bs-window').val()
                         };
                         // The window fields only mean something on a time step.
@@ -727,8 +744,8 @@
                                     // coercing it would quietly turn "then the door opens" into
                                     // "and the door is open". Leave it, and let the warning say so.
                                     : (i > 0 && condFirst && isCondition(rule.steps[i])) ? ['is']
-                                    : (src === 'thing' || src === 'group') ? (i === 0 ? ['is', 'becomes', 'cycle'] : ALL_PATTERNS)
-                                    : (i === 0 ? ['is'] : ['is', 'isOrBecomes']);
+                                    : (src === 'thing' || src === 'group') ? (i === 0 ? ['is', 'held', 'becomes', 'cycle'] : ALL_PATTERNS)
+                                    : (i === 0 ? ['is', 'held'] : ['is', 'isOrBecomes', 'held']);
                         var patSel = el.find('.bs-pattern');
                         var wasPat = patSel.val();
                         setPatternOptions(patSel, allowed, wasPat);
@@ -743,18 +760,21 @@
 
                         var pat = patSel.val();
                         // A condition reads "and …"; an event reads "then …".
-                        var isCond = (pat === 'is' || pat === 'isOrBecomes');
+                        var isCond = (pat === 'is' || pat === 'isOrBecomes' || pat === 'held');
                         el.find('.bs-lead').text(i === 0 ? (cont ? 'While' : 'When') : (isCond ? 'and' : 'then'));
-                        var showWindow = i > 0 && pat !== 'is';
+                        var showWindow = i > 0 && pat !== 'is' && pat !== 'held';
                         var showCycle = (pat === 'cycle');
+                        var showHold  = (pat === 'held');
                         timing.find('.bs-window-span').toggle(showWindow);
                         timing.find('.bs-cycle-span').toggle(showCycle);
+                        timing.find('.bs-hold-span').toggle(showHold);
                         timing.find('.bs-cycle-sep').toggle(showWindow && showCycle);
+                        timing.find('.bs-hold-sep').toggle(showWindow && showHold);
                         timing.find('.bs-days-span').toggle(isTime);
                         timing.find('.bs-days-sep').toggle(isTime && showWindow);
                         // The dot only earns its place when something follows the qualifier.
-                        timing.find('.bs-pat-sep').toggle(allowed.length > 1 && (showWindow || showCycle || isTime));
-                        timing.toggle(allowed.length > 1 || showWindow || showCycle || isTime);
+                        timing.find('.bs-pat-sep').toggle(allowed.length > 1 && (showWindow || showCycle || showHold || isTime));
+                        timing.toggle(allowed.length > 1 || showWindow || showCycle || showHold || isTime);
 
                         // Pin down what bounds the step, so "soon" is never left undefined.
                         timing.find('.bs-window-lead').text(pat === 'isOrBecomes'

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -179,7 +179,9 @@
     <p>The strength <b>scaled&hellip;</b> makes a rule's weight depend on the measured value instead
     of being constant. Give two points &mdash; <i>value 20 or less &rarr; weight 150 %</i>,
     <i>value 60 or more &rarr; weight 0 %</i> &mdash; and the weight is interpolated between them and
-    clamped outside. A rule's <b>weight</b> is its share of the way to on, the same percentage the
+    clamped outside. A rule's <b>weight</b> is its share of the way to the threshold this
+    configuration can cross &mdash; normally to on, but a prior above the on-threshold rests the
+    output on, and then the share is measured to off. It is the same percentage the
     bars show: 100 % is exactly enough to flip the output when nothing opposes it. Soil moisture is the natural
     example: watering in direct sun is normally a bad idea, but critically dry soil should override
     it, which only works if the dryness rule grows heavier as the reading falls.</p>
@@ -787,7 +789,7 @@
 
                     var scaled = (rule.strength === 'scaled' && rule.steps.length === 1);
                     var lr = effectiveLr(rule);
-                    var share = scaled ? maxScaleShare(rule) : scale.shareOfWay(lr, p.prior, p.pOn, p.clamp);
+                    var share = scaled ? maxScaleShare(rule) : scale.shareOfWay(lr, p.prior, p.pOn, p.clamp, p.pOff);
                     var sPct = pct(share);
 
                     container.find('.br-scale-span').toggle(scaled);
@@ -808,11 +810,15 @@
                     bar.css({ width: Math.min(100, Math.abs(share) * 100) + '%',
                               background: share >= 0 ? '#4b8' : '#c66' });
 
+                    // Which way "the way" runs: a prior above the on-threshold rests on, so a
+                    // rule earns its share by pushing the output down rather than up.
+                    var toward  = scale.restsOn(p.prior, p.pOn) ? 'off' : 'on';
+                    var against = toward === 'on' ? 'off' : 'on';
                     var capt = scaled
-                        ? 'up to ' + sPct + ' %' + (share >= 1 ? ' — enough alone' : ' of the way to on')
+                        ? 'up to ' + sPct + ' %' + (share >= 1 ? ' — enough alone' : ' of the way to ' + toward)
                         : (sPct >= 0
-                            ? sPct + ' % of the way to on' + (share >= 1 ? ' — enough on its own' : '')
-                            : sPct + ' % (pushes toward off)');
+                            ? sPct + ' % of the way to ' + toward + (share >= 1 ? ' — enough on its own' : '')
+                            : sPct + ' % (pushes toward ' + against + ')');
                     container.find('.br-share-caption').text(capt);
 
                     var custom = Number(rule.lr) > 0;
@@ -851,7 +857,7 @@
                         var scaledRule = (rule.strength === 'scaled' && rule.steps.length === 1);
                         var lr = effectiveLr(rule);
                         var share = scaledRule ? maxScaleShare(rule)
-                                               : scale.shareOfWay(lr, p.prior, p.pOn, p.clamp);
+                                               : scale.shareOfWay(lr, p.prior, p.pOn, p.clamp, p.pOff);
                         if (scaledRule) { anyScaled = true; }
                         if (share > 0) {
                             totalPos += share;
@@ -862,12 +868,25 @@
                         }
                     });
 
+                    // A prior above the on-threshold rests the output ON, so the summary is about
+                    // what turns it off. Saying "turns on" there would describe the opposite of
+                    // what the node does.
+                    var inverted = scale.restsOn(p.prior, p.pOn);
                     var lines = [];
+                    if (inverted) {
+                        lines.push('<b>Rests on</b> — the prior (' + p.prior + ') is above the on-threshold (' +
+                            p.pOn + '), so the output starts on and rules push it off.');
+                    }
                     lines.push('<b>Together: ' + (anyScaled ? 'up to ' : '') + pct(totalPos) + ' %</b> → ' +
-                        (totalPos >= 1 ? 'turns on.' : 'not enough to turn on.') + ' ' +
+                        (totalPos >= 1 ? (inverted ? 'turns off.' : 'turns on.')
+                                       : ('not enough to turn ' + (inverted ? 'off.' : 'on.'))) + ' ' +
                         (anyAlone ? 'At least one rule is enough on its own.' : 'No single rule is enough on its own.'));
 
-                    if ($("#node-input-latch").is(':checked')) {
+                    if (inverted) {
+                        // Decay runs the other way too: with nothing pushing, the estimate
+                        // returns to the prior, which is above the threshold.
+                        lines.push('With no rule active the estimate returns to the prior, so silence reads as on.');
+                    } else if ($("#node-input-latch").is(':checked')) {
                         var hold = $("#node-input-maxHold").val();
                         lines.push('Once on, the output stays on until a "makes it false" rule fires' +
                             (Number(hold) > 0 ? ' (or after ' + hold + ' h without supporting evidence).' : '.'));

--- a/core/bayes.js
+++ b/core/bayes.js
@@ -54,7 +54,7 @@ module.exports = function(RED) {
                     : scale.fadeSeconds(r.fade) * 1000;
                 const steps = (r.steps || []).map((s, si) => {
                     const src = ['thing', 'group', 'flow', 'global', 'env', 'time'].indexOf(s.src) >= 0 ? s.src : 'thing';
-                    let pattern = ['cycle', 'is', 'isOrBecomes', 'becomes'].indexOf(s.pattern) >= 0 ? s.pattern : 'is';
+                    let pattern = ['cycle', 'is', 'isOrBecomes', 'becomes', 'held'].indexOf(s.pattern) >= 0 ? s.pattern : 'is';
                     // Polled sources have no change event, so an edge on them could only be
                     // sampled on the tick and would be missed outright between two ticks. A
                     // group is not polled — it emits on the bus exactly like a thing — so it
@@ -79,7 +79,8 @@ module.exports = function(RED) {
                         operator: s.operator, value: s.value, valueType: s.valueType || 'str',
                         pattern,
                         cycleMaxMs: sec(s.cycleMax, 180),
-                        windowMs: sec(s.window, 120)
+                        windowMs: sec(s.window, 120),
+                        holdMs: sec(s.hold, 600)
                     };
                 }).filter(s => {
                     if (s.src === 'thing') { return s.thing && s.item; }

--- a/lib/bayes.js
+++ b/lib/bayes.js
@@ -54,7 +54,10 @@ function createBayes(cfg) {
     // A rule's log-odds contribution. Constant for a word strength or raw LR; for a scaled
     // rule it follows the measured value, which is what makes the weight track the reading.
     // null means "contributes nothing this evaluation" — a non-numeric or missing reading.
-    const gain = requiredGain(cfg.prior, cfg.pOn);
+    // Measured against whichever threshold this configuration can actually cross — a prior above
+    // pOn rests on, and the way out is down to pOff. Without pOff here the gain would come out
+    // negative and every reported share would flip sign.
+    const gain = requiredGain(cfg.prior, cfg.pOn, cfg.pOff);
     function ruleLn(rule, value) {
         if (!rule.scale) { return clampLn(Math.log(rule.lr)); }
         const share = scaleShare(value, rule.scale);

--- a/lib/bayes.js
+++ b/lib/bayes.js
@@ -75,7 +75,7 @@ function createBayes(cfg) {
     // as every one of them holds at once. "While it is 09:00–10:00 and the terrace is above
     // 100 lux" is one weight with two conditions, not a sequence — a condition is not an event,
     // so nothing would ever drive it forward.
-    const isCondition  = st => st.pattern === 'is' || st.pattern === 'isOrBecomes';
+    const isCondition  = st => st.pattern === 'is' || st.pattern === 'isOrBecomes' || st.pattern === 'held';
     const isContinuous = r => r.steps.every(isCondition);
     // …and a rule that opens with a condition but waits for an event later can never start:
     // the first step has no edge to complete it. The editor warns about this while you write
@@ -111,6 +111,24 @@ function createBayes(cfg) {
             const b = CONVERTERS[step.valueType || 'str'](step.value);
             return cmp(raw, b);
         } catch (e) { return false; }
+    }
+
+    // A condition with the 'held' qualifier is only satisfied once it has been continuously
+    // true for its own duration — "up for ten minutes", not "up right now". That is what
+    // separates a bathroom trip from getting up for the day, and it is a property of time
+    // rather than of the reading, so it cannot live in conditionMatches.
+    //
+    // The rising edge is already tracked for the overlap rule, so the duration is measured
+    // from it. A condition found true with no edge on record — true while the node was down,
+    // or on the very first evaluation — starts its clock now rather than counting as held: a
+    // hold that has not been observed has not been observed.
+    function conditionHolds(rule, step, index, raw, now) {
+        const matched = conditionMatches(step, raw);
+        if (step.pattern !== 'held') { return matched; }
+        const key = stepKey(rule.id, index);
+        if (!matched) { return false; }
+        if (typeof S.lastTrueEdge[key] !== 'number') { S.lastTrueEdge[key] = now; }
+        return (now - S.lastTrueEdge[key]) >= (step.holdMs || 0);
     }
 
     function fsmFor(ruleId) {
@@ -155,12 +173,14 @@ function createBayes(cfg) {
         // at the moment the previous step completed, or the sequence does not apply.
         // 'isOrBecomes' accepts the same, but falls back to waiting for the change,
         // for sensors that report late.
-        if (next.pattern === 'is' || next.pattern === 'isOrBecomes') {
+        if (next.pattern === 'is' || next.pattern === 'isOrBecomes' || next.pattern === 'held') {
             const raw = resolveState ? resolveState(next) : undefined;
-            if (conditionMatches(next, raw)) {
+            if (conditionHolds(rule, next, f.stepIndex, raw, doneAt)) {
                 completeStep(rule, f, doneAt, fired, resolveState);
                 return;
             }
+            // 'is' is strict and gives up here. 'held' is not failing, it is waiting for time
+            // to pass, so it stays armed and the tick re-checks it within its window.
             if (next.pattern === 'is') { resetFsm(rule.id); return; }
         }
 
@@ -244,8 +264,8 @@ function createBayes(cfg) {
                 // arrives from a polled source (flow/global/env has no change event).
                 // Re-check its level here so "now or soon" means that for them too.
                 const step = rule.steps[f.stepIndex];
-                if (step && f.stepIndex > 0 && step.pattern === 'isOrBecomes' && resolveState) {
-                    if (conditionMatches(step, resolveState(step))) {
+                if (step && f.stepIndex > 0 && (step.pattern === 'isOrBecomes' || step.pattern === 'held') && resolveState) {
+                    if (conditionHolds(rule, step, f.stepIndex, resolveState(step), now)) {
                         completeStep(rule, f, now, fired, resolveState);
                         continue;
                     }
@@ -289,7 +309,7 @@ function createBayes(cfg) {
                 let holds = true;
                 for (let i = 0; i < rule.steps.length && holds; i++) {
                     const v = i === 0 ? raw : resolveState(rule.steps[i]);
-                    holds = conditionMatches(rule.steps[i], v);
+                    holds = conditionHolds(rule, rule.steps[i], i, v, now);
                     // Name the step that failed: with several conditions, "which one" is the
                     // whole question.
                     if (!holds && rule.steps.length > 1) { e.failedStep = i + 1; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.10.3",
+      "version": "2.11.0",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.10.0",
+  "version": "2.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.10.0",
+      "version": "2.10.2",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.10.2",
+      "version": "2.10.3",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/resources/bayes-label.js
+++ b/resources/bayes-label.js
@@ -27,7 +27,8 @@
     // 'isOrBecomes' carry none: the lead word already said they are conditions.
     var PATTERNS = {
         becomes: 'on change',
-        cycle: 'on a full cycle'
+        cycle: 'on a full cycle',
+        held: 'for a while'
     };
 
     // The lead word, matching what the editor prints in .bs-lead (core/bayes.html). A rule
@@ -35,14 +36,15 @@
     // "When …", and later steps read "and" or "then" depending on their own pattern.
     function lead(step, index, continuous) {
         if (index === 0) { return continuous ? 'While' : 'When'; }
-        return (step.pattern === 'is' || step.pattern === 'isOrBecomes') ? 'and' : 'then';
+        return isCondition(step) ? 'and' : 'then';
     }
 
     // A rule is continuous when every step is a level check — the same test the estimator uses
     // to decide whether a rule holds a weight or fires one (lib/bayes.js). Several conditions
     // read as one "While A and B": they all have to hold at once.
     function isCondition(step) {
-        return !!step && (step.pattern === 'is' || step.pattern === 'isOrBecomes');
+        return !!step && (step.pattern === 'is' || step.pattern === 'isOrBecomes' ||
+                          step.pattern === 'held');
     }
     function isContinuous(rule) {
         return !!(rule && rule.steps && rule.steps.length && rule.steps.every(isCondition));

--- a/resources/bayes-scale.js
+++ b/resources/bayes-scale.js
@@ -58,15 +58,33 @@
         return 1200; // normal
     }
 
-    // The log-odds gain a rule set must supply to take the estimate from the
-    // prior to the on-threshold.
-    function requiredGain(prior, pOn) { return logit(pOn) - logit(prior); }
+    // The log-odds a rule set must supply to flip the output from where it rests.
+    //
+    // Normally the node rests off — the prior sits below the on-threshold — and the distance
+    // that matters is up to pOn. But a prior *above* pOn is a legitimate and useful
+    // configuration: the node rests on and evidence pushes it off, which is how you say "assume
+    // the house is quiet until something says otherwise". There the distance that matters is
+    // down to pOff, and measuring against pOn instead makes the gain negative — which silently
+    // turns every negative rule into a positive share, because two negatives divide positive.
+    //
+    // So the reference is whichever threshold the node would actually cross. Both branches
+    // return a signed gain, so a rule pushing the way the node can move always reports a
+    // positive share, and shares still add: there is one denominator either way.
+    function requiredGain(prior, pOn, pOff) {
+        if (pOff !== undefined && logit(prior) >= logit(pOn)) {
+            return logit(pOff) - logit(prior);        // rests on; the way out is down
+        }
+        return logit(pOn) - logit(prior);
+    }
+
+    // Which way this configuration can move from rest, for wording that has to follow.
+    function restsOn(prior, pOn) { return logit(prior) >= logit(pOn); }
 
     // Share of the way to "on" for an effective likelihood ratio (direction
     // already applied — lr < 1 yields a negative share). Returned as a fraction
     // (0.74 = 74 %).
-    function shareOfWay(lr, prior, pOn, clamp) {
-        return clampLn(Math.log(lr), clamp) / requiredGain(prior, pOn);
+    function shareOfWay(lr, prior, pOn, clamp, pOff) {
+        return clampLn(Math.log(lr), clamp) / requiredGain(prior, pOn, pOff);
     }
 
     // Maps a measured value onto a share, linearly between two points and clamped to the
@@ -96,8 +114,8 @@
     }
 
     // Inverse of shareOfWay: a share back to the log-odds it contributes.
-    function shareToLn(share, prior, pOn, clamp) {
-        return clampLn(share * requiredGain(prior, pOn), clamp);
+    function shareToLn(share, prior, pOn, clamp, pOff) {
+        return clampLn(share * requiredGain(prior, pOn, pOff), clamp);
     }
 
     // Scenario estimate for the summary line: all continuous rules inactive, the
@@ -138,6 +156,7 @@
         strengthLr: strengthLr,
         fadeSeconds: fadeSeconds,
         requiredGain: requiredGain,
+        restsOn: restsOn,
         shareOfWay: shareOfWay,
         scaleShare: scaleShare,
         shareToLn: shareToLn,

--- a/test/bayes.test.js
+++ b/test/bayes.test.js
@@ -992,3 +992,56 @@ describe('unusable operator and value pairings', function() {
         assert.strictEqual(byId(b.evaluate(stateOf({ a: 'x' }), 0), 'j').status, 'condition-false');
     });
 });
+
+describe('a prior above the on-threshold', function() {
+    // "Assume the house is quiet until something says otherwise": the node rests on and rules
+    // push it off. The estimate always handled this; what did not was every report of it,
+    // because requiredGain came out negative and two negatives divide positive — so a rule
+    // pushing the output down was described as pushing it up.
+    const P = { prior: 0.93, pOn: 0.80, pOff: 0.35, clamp: 6 };
+    const veto = (id, strength) => ({ id, lr: 1 / scale.strengthLr(strength), halfLifeMs: null,
+                                      steps: [step('is', { thing: id })] });
+    const make = rules => createBayes(cfgOf(Object.assign({}, P, { rules })));
+
+    it('measures the way to off, since that is the way it can move', function() {
+        const gain = scale.requiredGain(P.prior, P.pOn, P.pOff);
+        assert.ok(gain < 0, 'the reachable threshold is below the prior');
+        assert.strictEqual(scale.restsOn(P.prior, P.pOn), true);
+
+        // One decisive veto is just enough — which is what the estimate does too.
+        const share = scale.shareOfWay(1 / scale.strengthLr('decisive'), P.prior, P.pOn, P.clamp, P.pOff);
+        assert.ok(Math.abs(share - 1.06) < 0.02, share);
+    });
+
+    it('reports a rule that pushes the output down as a positive share', function() {
+        // The bug as reported: decisive-false read as +283 % of the way to ON.
+        const b = make([veto('motion', 'decisive')]);
+        const r = b.evaluate(stateOf({ motion: true }), 0);
+        assert.strictEqual(r.binary, false, 'the estimate was always right');
+        assert.ok(Math.abs(byId(r, 'motion').share - 106) < 1, byId(r, 'motion').share);
+    });
+
+    it('keeps shares additive against the one denominator', function() {
+        const b = make([veto('tv', 'slight'), veto('motion', 'decisive')]);
+        const r = b.evaluate(stateOf({ tv: true, motion: true }), 0);
+        const sum = active(r).reduce((t, x) => t + x.share, 0);
+        assert.ok(Math.abs(sum - r.share) < 0.2, sum + ' vs ' + r.share);
+    });
+
+    it('rests on and is pushed off, not the other way round', function() {
+        const b = make([veto('tv', 'slight'), veto('motion', 'decisive')]);
+        assert.strictEqual(b.evaluate(stateOf({}), 0).binary, true, 'silence reads as on');
+        assert.strictEqual(b.evaluate(stateOf({ tv: true }), MIN).binary, true, 'a slight veto is not enough');
+        assert.strictEqual(b.evaluate(stateOf({ motion: true }), 2 * MIN).binary, false, 'a decisive one is');
+        assert.strictEqual(b.evaluate(stateOf({}), 3 * MIN).binary, true, 'and it comes back');
+    });
+
+    it('leaves an ordinary configuration exactly as it was', function() {
+        // The fix must not move the normal case: prior below the threshold still measures up.
+        assert.strictEqual(scale.restsOn(0.2, 0.85), false);
+        const withOff = scale.shareOfWay(10, 0.2, 0.85, 6, 0.30);
+        const without = scale.shareOfWay(10, 0.2, 0.85, 6);
+        assert.strictEqual(withOff, without);
+        assert.ok(Math.abs(withOff - 0.7378) < 1e-3);
+    });
+});

--- a/test/bayes.test.js
+++ b/test/bayes.test.js
@@ -1045,3 +1045,84 @@ describe('a prior above the on-threshold', function() {
         assert.ok(Math.abs(withOff - 0.7378) < 1e-3);
     });
 });
+
+describe('a condition that must have held', function() {
+    // "Up for ten minutes" rather than "up right now" — what separates a bathroom trip from
+    // getting up for the day. It is a property of time, not of the reading, so it cannot be
+    // decided by the condition alone.
+    const heldRule = (id, lr, holdMs) => ({ id, lr, halfLifeMs: null,
+        steps: [step('held', { thing: id, holdMs: holdMs })] });
+    const TEN = 10 * MIN;
+
+    it('does not count until the condition has held long enough', function() {
+        const b = createBayes(cfgOf({ rules: [heldRule('up', 10, TEN)] }));
+        const R = stateOf({ up: true });
+
+        assert.strictEqual(active(b.evaluate(R, 0)).length, 0, 'just became true');
+        assert.strictEqual(active(b.evaluate(R, 5 * MIN)).length, 0, 'halfway');
+        assert.strictEqual(active(b.evaluate(R, TEN)).length, 1, 'exactly at the limit');
+        assert.strictEqual(active(b.evaluate(R, 30 * MIN)).length, 1, 'and stays');
+    });
+
+    it('starts over when the condition drops', function() {
+        // The bathroom trip: up, back to bed, up again — the clock restarts each time, so a
+        // string of short absences never adds up to a long one.
+        const b = createBayes(cfgOf({ rules: [heldRule('up', 10, TEN)] }));
+        const state = { up: true };
+        const R = stateOf(state);
+        b.evaluate(R, 0);
+        b.handleEvent(hit('up', 0), true, 0);
+
+        state.up = false;
+        b.handleEvent(hit('up', 0), false, 8 * MIN);
+        assert.strictEqual(active(b.evaluate(R, 8 * MIN)).length, 0);
+
+        state.up = true;
+        b.handleEvent(hit('up', 0), true, 9 * MIN);
+        assert.strictEqual(active(b.evaluate(R, 17 * MIN)).length, 0,
+            '8 minutes then 8 more is not 10 in a row');
+        assert.strictEqual(active(b.evaluate(R, 19 * MIN)).length, 1, 'ten from the restart');
+    });
+
+    it('starts the clock when it first sees the condition true', function() {
+        // True while the node was down, or true at the very first evaluation: a hold that has
+        // not been observed has not been observed, so it counts from now rather than forever.
+        const b = createBayes(cfgOf({ rules: [heldRule('up', 10, TEN)] }));
+        const R = stateOf({ up: true });
+        assert.strictEqual(active(b.evaluate(R, 1000 * MIN)).length, 0, 'not credited on sight');
+        assert.strictEqual(active(b.evaluate(R, 1010 * MIN)).length, 1, 'ten minutes later');
+    });
+
+    it('makes a rule of held steps continuous, not a sequence', function() {
+        // Otherwise it would go to the sequence machinery and never fire — a condition is not
+        // an event, whether or not it has to last.
+        const b = createBayes(cfgOf({ rules: [{ id: 'r', lr: 10, halfLifeMs: null, steps: [
+            step('held', { thing: 'a', holdMs: TEN }),
+            step('is',   { thing: 'b' })
+        ]}]}));
+        const R = stateOf({ a: true, b: true });
+        assert.strictEqual(byId(b.evaluate(R, 0), 'r').status, 'condition-false', 'a has not held yet');
+        assert.strictEqual(byId(b.evaluate(R, TEN), 'r').status, 'contributing');
+        assert.strictEqual(byId(b.evaluate(stateOf({ a: true, b: false }), TEN), 'r').status,
+            'condition-false', 'still an AND');
+    });
+
+    it('a zero duration behaves exactly like an ordinary condition', function() {
+        const b = createBayes(cfgOf({ rules: [heldRule('up', 10, 0)] }));
+        assert.strictEqual(active(b.evaluate(stateOf({ up: true }), 0)).length, 1);
+        assert.strictEqual(active(b.evaluate(stateOf({ up: false }), MIN)).length, 0);
+    });
+
+    it('survives a restart with the hold intact', function() {
+        // The edge is persisted with the rest of the state, so a deploy does not reset a
+        // condition that has genuinely been true for an hour.
+        const a = createBayes(cfgOf({ rules: [heldRule('up', 10, TEN)] }));
+        a.handleEvent(hit('up', 0), true, 0);
+        const saved = a.serialize();
+
+        const b = createBayes(cfgOf({ rules: [heldRule('up', 10, TEN)] }));
+        b.restore(saved, 20 * MIN);
+        assert.strictEqual(active(b.evaluate(stateOf({ up: true }), 20 * MIN)).length, 1,
+            'twenty minutes of holding survived the restart');
+    });
+});


### PR DESCRIPTION
Two changes, both found while modelling "the house is in night mode" — a design where the prior
sits *above* the on-threshold, so the node rests on and rules push it off. That turns out to be a
useful way to say "assume the house is quiet until something says otherwise": no rule has to argue
the resting case, and silence is the answer rather than something to reconstruct.

## Shares were measured toward a threshold the node could not reach

`requiredGain` is `logit(pOn) − logit(prior)`, which goes negative when the prior is above the
on-threshold. A rule pushing the output down has a negative `ln(LR)`. Two negatives divide
positive — so a decisive *makes it false* was reported as **+283 % of the way to on**, and the
editor summarised a rule set that only ever turns things off as "692 % → turns on".

The estimate underneath was right the whole time, which is what made it look cosmetic. It was not:
the runtime uses the same gain to scale a value-following weight, so a **scaled rule in this
configuration computed the wrong direction**.

The gain now references whichever threshold the configuration can actually cross — `pOn` when the
node rests off, `pOff` when it rests on. Both branches return a signed gain, so a rule pushing the
way the node can move always reports a positive share, and shares still add against one
denominator. An ordinary configuration is byte-identical, which a test pins by comparing the result
with and without the new argument.

The editor follows: bars read "of the way to off", the summary leads with *"Rests on — the prior
(0.93) is above the on-threshold (0.8), so the output starts on and rules push it off"*, and the
decay sentence is replaced, since with nothing pushing the estimate returns to a prior above the
line and silence reads as on.

Reported from a live node at prior 0.93 showing 34 % and 283 % for two vetoes. Those now read 13 %
and 106 % — and 106 % is exactly right: one decisive rule takes 0.93 to 0.307, just past an
off-threshold of 0.35.

## A "for a while" step qualifier

A condition that must have been continuously true for its own duration before it counts.

The problem that produced it: a trip to the bathroom and getting up for the day are identical
readings at the moment they happen, and only time tells them apart. The workaround being replaced
was *requiring two people to be up* — which filtered the bathroom trip, but only for a two-person
household. With one person home it filtered out the case that should pass, since one person up is
then the entire household. Count was standing in for duration and only worked by coincidence of
household size.

With the qualifier the model says what it means — decisive per person, filtered by persistence,
correct at any number of people home:

| | p | |
|---|---|---|
| everyone asleep | 0.93 | night |
| bathroom trip, 2 min | 0.93 | night |
| one up > 10 min | 0.31 | → day |
| one person home, up > 10 min | 0.31 | → day |

Three decisions worth knowing. The duration is measured from the rising edge already tracked for
the sequence overlap rule, so **a genuine hold survives a restart** rather than being reset by a
deploy. A condition found true with *no* edge on record — true while the node was down, or on the
very first evaluation — starts its clock then rather than counting as held: a hold that has not
been observed has not been observed. And the clock **restarts** whenever the condition drops, so
eight minutes, back to bed, eight more is not ten in a row — which is what makes it a filter
against repeated short blips rather than a stopwatch.

It counts as a condition everywhere that matters: a rule of them is continuous rather than a
sequence, and inside a sequence it waits for its time rather than failing the step.

## Testing

324 passing. The new ones cover both directions of the share arithmetic (including that an ordinary
configuration is untouched), and the qualifier's edges — not credited on sight, the clock
restarting, a zero duration behaving as a plain condition, and a hold surviving serialize/restore.
