### PR TITLE
Compare a source against another source (2.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,25 @@ convincing. The node is an anonymous estimator: it knows nothing about people, i
 evidence. Use one node per hypothesis (one per person) and wire its output onward like any
 other message — e.g. into a Scene-type sensor representing the person.
 
+### Comparing against another source
+
+Every comparison in hal2Gate, hal2Event and hal2Bayes normally weighs a source against a
+**constant** — a number, a string, or a variable. Pick the **state** value type instead and the
+right-hand side is another live reading: another Thing's Item, or a Group with a function of its own.
+
+This is worth more than the convenience. The alternative was storing one side in a flow variable
+and comparing against that, which samples the two sides at different moments: something changes,
+the variable has not caught up, and the comparison is silently wrong until it corrects itself. With
+`state` both sides are read in the same pass, so the window does not exist. "Is everyone who is
+home asleep?" becomes one rule — *people home* `count true` **==** *phones charging* `count true` —
+with nothing stored in between.
+
+The right-hand side is described the same way everywhere: a source, and an item or group function.
+It is offered wherever comparing two values makes sense, so not for *is true*/*is false*, *regex*,
+or the Gate's `last_*` operators, which compare against a duration. A source that cannot be read —
+a deleted Thing, a group with no live member — makes the rule not match rather than comparing
+against nothing.
+
 ### Rules
 
 Each rule collapses to a single line stating what it says and what it does about it — the same

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -134,6 +134,11 @@
         <li><b>on a full cycle</b> &mdash; a cycle: true and back to false within its limit, e.g. a
             door opening and closing. Reads <i>then&hellip;</i></li>
     </ul>
+    <p>A step's value is normally a constant. Choose the <b>state</b> type and it is another live
+    reading instead &mdash; another thing's item, or a group with a function of its own &mdash; read
+    in the same pass as the step's own source, so the two cannot disagree because one was stored
+    earlier. A comparison source that cannot be read makes the step not match rather than comparing
+    against nothing.</p>
     <p>A rule whose steps are <b>all conditions</b> is not a sequence but an <b>AND</b>: its weight
     applies while every one of them holds at the same time, and it reads <i>While A and B</i>. A rule
     that opens with a condition but waits for an event later cannot work &mdash; nothing completes
@@ -513,6 +518,24 @@
                         .appendTo(valWrap).typedInput({ default: step.valueType || 'str', types: ['str', 'num', 'bool', 're'] });
                     $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(line2);
                     valField.typedInput('value', step.value === undefined ? '' : step.value);
+
+                    // The comparison source, when the value is another live reading rather than a
+                    // constant. Its own line: line 2 already carries the operator and the value,
+                    // and this is a source picker of the same weight as the one on line 1.
+                    var cmpRow = $('<div/>', { class: "bs-cmp-row",
+                        style: "display:flex; align-items:center; margin-top:4px;" }).appendTo(stepDiv).hide();
+                    $('<span/>', { style: "flex:0 0 50px; text-align:right; padding-right:8px; box-sizing:border-box; color:#888;" })
+                        .appendTo(cmpRow).text('vs');
+                    var cmpSel  = $('<select/>', { class: "bs-cmp", style: "flex:5 1 0; min-width:0;" }).appendTo(cmpRow);
+                    var cmpItem = $('<select/>', { class: "bs-cmpitem", style: "flex:3 1 0; min-width:0; margin-left:4px;" }).appendTo(cmpRow);
+                    var cmpFn   = $('<select/>', { class: "bs-cmpfn", style: "flex:3 1 0; min-width:0; margin-left:4px;" }).appendTo(cmpRow);
+                    $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(cmpRow);
+                    var syncCmp = halFillSourcePicker(cmpSel, cmpItem, cmpFn, thingsList, groupsList, step.cmp);
+                    cmpSel.change(syncCmp);
+                    syncCmp();
+                    valField.on('change', function() {
+                        cmpRow.toggle(valField.typedInput('type') === 'state');
+                    });
                     // Line 3 — when the condition has to hold, plus the numbers that bound it.
                     // Deliberately off the condition line: that one says *what*, this says
                     // *when*, and read in sequence they became "When ... when it changes".
@@ -649,6 +672,7 @@
                             opSel.css('flex', '0 0 130px');
                             halOperators().forEach(function(o) { opSel.append($("<option></option>").val(o.v).text(o.t)); });
                             opSel.val(current);
+                            valField.typedInput('types', ['str', 'num', 'bool', 're', halTypeState()]);
                         }
                         opHandler();
                     }
@@ -698,6 +722,9 @@
                             src:      src,
                             thing:    el.find('.bs-thing option:selected').val(),
                             group:    el.find('.bs-group option:selected').val() || '',
+                            cmp:      el.find('.bs-val').typedInput('type') === 'state'
+                                        ? halReadSourcePicker(el.find('.bs-cmp'), el.find('.bs-cmpitem'), el.find('.bs-cmpfn'))
+                                        : null,
                             groupFunction: el.find('.bs-groupfn option:selected').val() || '',
                             item:     el.find('.bs-item option:selected').val(),
                             prop:     el.find('.bs-prop').val(),
@@ -801,7 +828,9 @@
                                        '"now or soon" has nothing to wait for and reads as "now".', 'warning');
                         }
                         patSel.toggle(allowed.length > 1);
-                        el.find('.bs-val-wrap').toggle(!isTime && ['true', 'false'].indexOf(el.find('.bs-op').val()) < 0);
+                        var takesValue = !isTime && ['true', 'false'].indexOf(el.find('.bs-op').val()) < 0;
+                        el.find('.bs-val-wrap').toggle(takesValue);
+                        el.find('.bs-cmp-row').toggle(takesValue && el.find('.bs-val').typedInput('type') === 'state');
 
                         var pat = patSel.val();
                         // A condition reads "and …"; an event reads "then …".

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -523,19 +523,45 @@
                     // The comparison source, when the value is another live reading rather than a
                     // constant. Its own line: line 2 already carries the operator and the value,
                     // and this is a source picker of the same weight as the one on line 1.
+                    // The source on one row and what is read from it on the next, mirroring the
+                    // separate rows the other two nodes use. Each spans flex:1 1 0 between the
+                    // 50px lead and the 34px remove-button pad, which is exactly the width line 1
+                    // gives its thing and item selects together — so the two sides of the
+                    // comparison line up down the dialog instead of stepping in and out.
                     var cmpRow = $('<div/>', { class: "bs-cmp-row",
                         style: "display:flex; align-items:center; margin-top:4px;" }).appendTo(stepDiv).hide();
                     $('<span/>', { style: "flex:0 0 50px; text-align:right; padding-right:8px; box-sizing:border-box; color:#888;" })
                         .appendTo(cmpRow).text('vs');
-                    var cmpSel  = $('<select/>', { class: "bs-cmp", style: "flex:5 1 0; min-width:0;" }).appendTo(cmpRow);
-                    var cmpItem = $('<select/>', { class: "bs-cmpitem", style: "flex:3 1 0; min-width:0; margin-left:4px;" }).appendTo(cmpRow);
-                    var cmpFn   = $('<select/>', { class: "bs-cmpfn", style: "flex:3 1 0; min-width:0; margin-left:4px;" }).appendTo(cmpRow);
+                    var cmpSel  = $('<select/>', { class: "bs-cmp", style: "flex:1 1 0; min-width:0;" }).appendTo(cmpRow);
                     $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(cmpRow);
-                    var syncCmp = halFillSourcePicker(cmpSel, cmpItem, cmpFn, thingsList, groupsList, step.cmp);
+
+                    var cmpRow2 = $('<div/>', { class: "bs-cmp-row2",
+                        style: "display:flex; align-items:center; margin-top:4px;" }).appendTo(stepDiv).hide();
+                    $('<span/>', { style: "flex:0 0 50px;" }).appendTo(cmpRow2);
+                    var cmpItem = $('<select/>', { class: "bs-cmpitem", style: "flex:1 1 0; min-width:0;" }).appendTo(cmpRow2);
+                    var cmpFn   = $('<select/>', { class: "bs-cmpfn", style: "flex:1 1 0; min-width:0;" }).appendTo(cmpRow2);
+                    $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(cmpRow2);
+
+                    var cmpTipRow = $('<div/>', { class: "bs-cmp-tip-row",
+                        style: "display:flex; align-items:center; margin-top:6px;" }).appendTo(stepDiv).hide();
+                    $('<span/>', { style: "flex:0 0 50px;" }).appendTo(cmpTipRow);
+                    var cmpTip = $('<div/>', { class: "form-tips bs-cmp-tip",
+                        style: "flex:1 1 0; min-width:0; max-width:none; box-sizing:border-box; white-space:normal;" })
+                        .appendTo(cmpTipRow);
+                    $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(cmpTipRow);
+
+                    var syncCmp = halFillSourcePicker(cmpSel, cmpItem, cmpFn, thingsList, groupsList, step.cmp,
+                        function(text) { cmpTip.text(text); cmpTipRow.toggle(!!text && cmpRow.is(':visible')); });
+                    // One place decides the whole block, so the three rows cannot drift apart.
+                    function showCmp(on) {
+                        cmpRow.toggle(on);
+                        cmpRow2.toggle(on);
+                        cmpTipRow.toggle(on && !!cmpTip.text());
+                    }
                     cmpSel.change(syncCmp);
                     syncCmp();
                     valField.on('change', function() {
-                        cmpRow.toggle(valField.typedInput('type') === 'state');
+                        showCmp(valField.typedInput('type') === 'state');
                     });
                     // Line 3 — when the condition has to hold, plus the numbers that bound it.
                     // Deliberately off the condition line: that one says *what*, this says
@@ -627,8 +653,8 @@
                         } else {
                             valField.typedInput('types', ['str', 'num', 'bool', 're', halTypeState()]);
                         }
-                        cmpRow.toggle(op !== 'true' && op !== 'false' &&
-                                      valField.typedInput('type') === 'state');
+                        showCmp(op !== 'true' && op !== 'false' &&
+                                valField.typedInput('type') === 'state');
                     };
                     opSel.change(opHandler);
 
@@ -839,7 +865,11 @@
                         patSel.toggle(allowed.length > 1);
                         var takesValue = !isTime && ['true', 'false'].indexOf(el.find('.bs-op').val()) < 0;
                         el.find('.bs-val-wrap').toggle(takesValue);
-                        el.find('.bs-cmp-row').toggle(takesValue && el.find('.bs-val').typedInput('type') === 'state');
+                        // All three compare rows, not just the first: refreshRuleView runs on
+                        // every change and would otherwise leave the item and tip rows behind.
+                        var showsCmp = takesValue && el.find('.bs-val').typedInput('type') === 'state';
+                        el.find('.bs-cmp-row, .bs-cmp-row2').toggle(showsCmp);
+                        el.find('.bs-cmp-tip-row').toggle(showsCmp && !!el.find('.bs-cmp-tip').text());
 
                         var pat = patSel.val();
                         // A condition reads "and …"; an event reads "then …".

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -523,24 +523,17 @@
                     // The comparison source, when the value is another live reading rather than a
                     // constant. Its own line: line 2 already carries the operator and the value,
                     // and this is a source picker of the same weight as the one on line 1.
-                    // The source on one row and what is read from it on the next, mirroring the
-                    // separate rows the other two nodes use. Each spans flex:1 1 0 between the
-                    // 50px lead and the 34px remove-button pad, which is exactly the width line 1
-                    // gives its thing and item selects together — so the two sides of the
-                    // comparison line up down the dialog instead of stepping in and out.
+                    // One row, in line 1's own proportions: the source at flex:5 and what is read
+                    // from it at flex:3, so the compare pair sits directly under the thing and
+                    // item it is being compared against.
                     var cmpRow = $('<div/>', { class: "bs-cmp-row",
                         style: "display:flex; align-items:center; margin-top:4px;" }).appendTo(stepDiv).hide();
                     $('<span/>', { style: "flex:0 0 50px; text-align:right; padding-right:8px; box-sizing:border-box; color:#888;" })
                         .appendTo(cmpRow).text('vs');
-                    var cmpSel  = $('<select/>', { class: "bs-cmp", style: "flex:1 1 0; min-width:0;" }).appendTo(cmpRow);
+                    var cmpSel  = $('<select/>', { class: "bs-cmp", style: "flex:5 1 0; min-width:0;" }).appendTo(cmpRow);
+                    var cmpItem = $('<select/>', { class: "bs-cmpitem", style: "flex:3 1 0; min-width:0; margin-left:4px;" }).appendTo(cmpRow);
+                    var cmpFn   = $('<select/>', { class: "bs-cmpfn", style: "flex:3 1 0; min-width:0; margin-left:4px;" }).appendTo(cmpRow);
                     $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(cmpRow);
-
-                    var cmpRow2 = $('<div/>', { class: "bs-cmp-row2",
-                        style: "display:flex; align-items:center; margin-top:4px;" }).appendTo(stepDiv).hide();
-                    $('<span/>', { style: "flex:0 0 50px;" }).appendTo(cmpRow2);
-                    var cmpItem = $('<select/>', { class: "bs-cmpitem", style: "flex:1 1 0; min-width:0;" }).appendTo(cmpRow2);
-                    var cmpFn   = $('<select/>', { class: "bs-cmpfn", style: "flex:1 1 0; min-width:0;" }).appendTo(cmpRow2);
-                    $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(cmpRow2);
 
                     var cmpTipRow = $('<div/>', { class: "bs-cmp-tip-row",
                         style: "display:flex; align-items:center; margin-top:6px;" }).appendTo(stepDiv).hide();
@@ -555,7 +548,6 @@
                     // One place decides the whole block, so the three rows cannot drift apart.
                     function showCmp(on) {
                         cmpRow.toggle(on);
-                        cmpRow2.toggle(on);
                         cmpTipRow.toggle(on && !!cmpTip.text());
                     }
                     cmpSel.change(syncCmp);
@@ -865,10 +857,10 @@
                         patSel.toggle(allowed.length > 1);
                         var takesValue = !isTime && ['true', 'false'].indexOf(el.find('.bs-op').val()) < 0;
                         el.find('.bs-val-wrap').toggle(takesValue);
-                        // All three compare rows, not just the first: refreshRuleView runs on
-                        // every change and would otherwise leave the item and tip rows behind.
+                        // The tip row as well as the compare row: refreshRuleView runs on every
+                        // change and would otherwise leave the tip behind.
                         var showsCmp = takesValue && el.find('.bs-val').typedInput('type') === 'state';
-                        el.find('.bs-cmp-row, .bs-cmp-row2').toggle(showsCmp);
+                        el.find('.bs-cmp-row').toggle(showsCmp);
                         el.find('.bs-cmp-tip-row').toggle(showsCmp && !!el.find('.bs-cmp-tip').text());
 
                         var pat = patSel.val();

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -614,13 +614,21 @@
                     var opHandler = function() {
                         var op = opSel.val();
                         valWrap.toggle(op !== 'true' && op !== 'false');
+                        // This runs on every operator change and at construction, so it is the
+                        // last writer of the type list — anything missing here is missing, however
+                        // carefully it was offered elsewhere.
                         if (op === 'regex') {
                             valField.typedInput('types', ['re']).typedInput('type', 're');
                         } else if (halNumericOperator(op)) {
-                            valField.typedInput('types', ['num']).typedInput('type', 'num');
+                            valField.typedInput('types', ['num', halTypeState()]);
+                            if (valField.typedInput('type') !== 'state') {
+                                valField.typedInput('type', 'num');
+                            }
                         } else {
-                            valField.typedInput('types', ['str', 'num', 'bool', 're']);
+                            valField.typedInput('types', ['str', 'num', 'bool', 're', halTypeState()]);
                         }
+                        cmpRow.toggle(op !== 'true' && op !== 'false' &&
+                                      valField.typedInput('type') === 'state');
                     };
                     opSel.change(opHandler);
 

--- a/core/bayes.html
+++ b/core/bayes.html
@@ -515,7 +515,8 @@
                     // that width). Otherwise it measures outerWidth() at construction — which runs
                     // while the Rules tab is still display:none, so the measurement is 0.
                     var valField = $('<input/>', { class: "bs-val", type: "text", style: "width:100%;" })
-                        .appendTo(valWrap).typedInput({ default: step.valueType || 'str', types: ['str', 'num', 'bool', 're'] });
+                        .appendTo(valWrap).typedInput({ default: step.valueType || 'str',
+                            types: ['str', 'num', 'bool', 're', halTypeState()] });
                     $('<span/>', { class: "bs-endpad", style: "flex:0 0 34px;" }).appendTo(line2);
                     valField.typedInput('value', step.value === undefined ? '' : step.value);
 

--- a/core/bayes.js
+++ b/core/bayes.js
@@ -71,9 +71,17 @@ module.exports = function(RED) {
                     // Waiting for the clock to cross into a window is never useful, so a time
                     // step is always a plain condition wherever it sits.
                     if (src === 'time') { pattern = 'is'; }
+                    // The comparison source is itself a step, so resolveState serves it
+                    // unchanged — a step can be compared against a thing, a group, or a
+                    // flow/global variable without the estimator learning anything new.
+                    const cmp = s.cmp && s.cmp.src ? {
+                        src: s.cmp.src, thing: s.cmp.thing, item: s.cmp.item,
+                        group: s.cmp.group, groupFunction: s.cmp.groupFunction || '',
+                        prop: s.cmp.prop
+                    } : null;
                     return {
                         src, thing: s.thing, item: s.item, group: s.group,
-                        groupFunction: s.groupFunction || '', prop: s.prop,
+                        groupFunction: s.groupFunction || '', prop: s.prop, cmp,
                         start: s.start, end: s.end,
                         days: Array.isArray(s.days) ? s.days.map(Number) : undefined,
                         operator: s.operator, value: s.value, valueType: s.valueType || 'str',

--- a/core/event.html
+++ b/core/event.html
@@ -31,6 +31,13 @@
             <select id="node-input-groupFunction" style="width:calc(100% - 170px)"></select>
         </div>
 
+        <div class="form-row" id="row-compare-source" hidden>
+            <label for="node-input-compareThing"><i class="fa fa-sitemap"></i> Compare</label>
+            <select id="node-input-compareThing" style="width:calc(55% - 60px)"></select>
+            <select id="node-input-compareItem" style="width:calc(45% - 60px); margin-left:4px;"></select>
+            <select id="node-input-compareFn" style="width:calc(45% - 60px); margin-left:4px;"></select>
+        </div>
+
         <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); max-width:none; box-sizing:border-box; margin-bottom:8px;">
             <small id="group-tip"></small>
         </div>
@@ -161,6 +168,7 @@
             change:         { value: "1" },
             compareValue:   { value: "" },
             compareType:    { value: "num" },
+            compareSource:  { value: null },
             outputValue:    { value: "" },
             outputType:     { required: true },
             ratelimit:      { value: false },
@@ -472,7 +480,19 @@
             $('#node-input-compareValue').typedInput({
                 default: 'num',
                 typeField: $("#node-input-compareType"),
-                types: ['str','num','json']
+                types: ['str','num','json',halTypeState()]
+            });
+
+            // Comparing against another live reading rather than a constant. Both sides are
+            // read when the event fires, so they cannot disagree because one was stored earlier.
+            var syncCompareSource = halFillSourcePicker(
+                $("#node-input-compareThing"), $("#node-input-compareItem"), $("#node-input-compareFn"),
+                thingsList, groupsList, this.compareSource);
+            $("#node-input-compareThing").change(syncCompareSource);
+            syncCompareSource();
+            $('#node-input-compareValue').on('change', function() {
+                $("#row-compare-source").toggle(
+                    $('#node-input-compareValue').typedInput('type') === 'state');
             });
             if (this.compareValue) {
                 $("#node-input-compareValue").typedInput('value',this.compareValue).typedInput('type',this.compareType);                           
@@ -545,6 +565,11 @@
             this.thing =   $("#node-input-thing").val();
             this.compareType = $('#node-input-compareValue').typedInput('type');
             this.compareValue =  $('#node-input-compareValue').typedInput('value');
+            this.compareSource = this.compareType === 'state'
+                ? halReadSourcePicker($("#node-input-compareThing"),
+                                      $("#node-input-compareItem"),
+                                      $("#node-input-compareFn"))
+                : null;
         }
     });
 </script>

--- a/core/event.html
+++ b/core/event.html
@@ -64,9 +64,17 @@
 
         <div class="form-row" id="row-compare-source" hidden>
             <label for="node-input-compareThing"><i class="fa fa-sitemap"></i> Compare</label>
-            <select id="node-input-compareThing" style="width:calc(55% - 60px)"></select>
-            <select id="node-input-compareItem" style="width:calc(45% - 60px); margin-left:4px;"></select>
-            <select id="node-input-compareFn" style="width:calc(45% - 60px); margin-left:4px;"></select>
+            <select id="node-input-compareThing" style="width:calc(100% - 170px)"></select>
+        </div>
+
+        <div class="form-row" id="row-compare-item" hidden>
+            <label for="node-input-compareItem" id="label-compare-item"><i class="fa fa-sitemap"></i> Item</label>
+            <select id="node-input-compareItem" style="width:calc(100% - 170px)"></select>
+            <select id="node-input-compareFn" style="width:calc(100% - 170px)"></select>
+        </div>
+
+        <div class="form-tips" id="row-compare-tip" style="margin-left:105px; width:calc(100% - 170px); max-width:none; box-sizing:border-box; margin-bottom:8px;" hidden>
+            <small id="compare-tip"></small>
         </div>
 
         <div class="form-row">
@@ -490,14 +498,27 @@
             // read when the event fires, so they cannot disagree because one was stored earlier.
             var syncCompareSource = halFillSourcePicker(
                 $("#node-input-compareThing"), $("#node-input-compareItem"), $("#node-input-compareFn"),
-                thingsList, groupsList, this.compareSource);
-            $("#node-input-compareThing").change(syncCompareSource);
-            syncCompareSource();
+                thingsList, groupsList, this.compareSource,
+                function(text) {
+                    $("#compare-tip").text(text);
+                    $("#row-compare-tip").toggle(!!text && $("#row-compare-source").is(':visible'));
+                });
+            $("#node-input-compareThing").change(function() {
+                // The same word the primary picker uses for the same thing: a group is read
+                // through a Value, a thing through an Item.
+                var isGroup = ($("#node-input-compareThing").val() || '').indexOf('g:') === 0;
+                $("#label-compare-item").text(isGroup ? ' Value' : ' Item')
+                    .attr('class', isGroup ? 'fa fa-calculator' : 'fa fa-sitemap');
+                syncCompareSource();
+            });
+            $("#node-input-compareThing").trigger('change');
             syncCompareRow = function() {
                 var op = $("#node-input-operator").val();
                 var takesValue = op !== 'always' && op !== 'true' && op !== 'false';
-                $("#row-compare-source").toggle(
-                    takesValue && $('#node-input-compareValue').typedInput('type') === 'state');
+                var on = takesValue && $('#node-input-compareValue').typedInput('type') === 'state';
+                $("#row-compare-source").toggle(on);
+                $("#row-compare-item").toggle(on);
+                $("#row-compare-tip").toggle(on && !!$("#compare-tip").text());
             };
             $('#node-input-compareValue').on('change', syncCompareRow);
             // The type is restored even when there is no value to restore: `state` carries none

--- a/core/event.html
+++ b/core/event.html
@@ -31,13 +31,6 @@
             <select id="node-input-groupFunction" style="width:calc(100% - 170px)"></select>
         </div>
 
-        <div class="form-row" id="row-compare-source" hidden>
-            <label for="node-input-compareThing"><i class="fa fa-sitemap"></i> Compare</label>
-            <select id="node-input-compareThing" style="width:calc(55% - 60px)"></select>
-            <select id="node-input-compareItem" style="width:calc(45% - 60px); margin-left:4px;"></select>
-            <select id="node-input-compareFn" style="width:calc(45% - 60px); margin-left:4px;"></select>
-        </div>
-
         <div class="form-tips" id="row-group-tip" style="margin-left:105px; width:calc(100% - 170px); max-width:none; box-sizing:border-box; margin-bottom:8px;">
             <small id="group-tip"></small>
         </div>
@@ -67,6 +60,13 @@
             <select id="node-input-operator" style="width:calc(100% - 170px)"></select>
             <input type="text" id="node-input-compareValue" style="width:calc(100% - 219px)>
             <input type="hidden" id="node-input-compareType">
+        </div>
+
+        <div class="form-row" id="row-compare-source" hidden>
+            <label for="node-input-compareThing"><i class="fa fa-sitemap"></i> Compare</label>
+            <select id="node-input-compareThing" style="width:calc(55% - 60px)"></select>
+            <select id="node-input-compareItem" style="width:calc(45% - 60px); margin-left:4px;"></select>
+            <select id="node-input-compareFn" style="width:calc(45% - 60px); margin-left:4px;"></select>
         </div>
 
         <div class="form-row">
@@ -188,6 +188,9 @@
         },
         paletteLabel: "event",
         oneditprepare: async function () {
+            // Assigned further down, once the compare field exists; the operator handler and the
+            // value's own change event both call it so one rule decides the row's visibility.
+            var syncCompareRow = function() {};
             var operators = halOperators([{ v: "always", t: "always"}]);
 
             var groupsList = halGetGroups(RED, $("#node-input-eventHandler").val(), 'value');
@@ -490,10 +493,13 @@
                 thingsList, groupsList, this.compareSource);
             $("#node-input-compareThing").change(syncCompareSource);
             syncCompareSource();
-            $('#node-input-compareValue').on('change', function() {
+            syncCompareRow = function() {
+                var op = $("#node-input-operator").val();
+                var takesValue = op !== 'always' && op !== 'true' && op !== 'false';
                 $("#row-compare-source").toggle(
-                    $('#node-input-compareValue').typedInput('type') === 'state');
-            });
+                    takesValue && $('#node-input-compareValue').typedInput('type') === 'state');
+            };
+            $('#node-input-compareValue').on('change', syncCompareRow);
             // The type is restored even when there is no value to restore: `state` carries none
             // (hasValue:false), so gating this on compareValue would load every saved state
             // comparison back as whatever type the field happened to default to.
@@ -555,11 +561,14 @@
                         $('#node-input-compareValue').typedInput('type','re');
                     } else {
                         $('#node-input-compareValue').typedInput('types',['num',halTypeState()]);
-                        $('#node-input-compareValue').typedInput('type','num');                        
+                        if ($('#node-input-compareValue').typedInput('type') !== 'state') {
+                            $('#node-input-compareValue').typedInput('type','num');
+                        }
                     }
                 } else {
                     $('#node-input-compareValue').typedInput('types',['str','num','json',halTypeState()]);
                 }
+                syncCompareRow();
             });
         },
         oneditsave: function () {

--- a/core/event.html
+++ b/core/event.html
@@ -494,9 +494,11 @@
                 $("#row-compare-source").toggle(
                     $('#node-input-compareValue').typedInput('type') === 'state');
             });
-            if (this.compareValue) {
-                $("#node-input-compareValue").typedInput('value',this.compareValue).typedInput('type',this.compareType);                           
-            }
+            // The type is restored even when there is no value to restore: `state` carries none
+            // (hasValue:false), so gating this on compareValue would load every saved state
+            // comparison back as whatever type the field happened to default to.
+            $("#node-input-compareValue").typedInput('value', this.compareValue || '');
+            if (this.compareType) { $("#node-input-compareValue").typedInput('type', this.compareType); }
 
             //On change, update
             $("<option value='0'>on update</option>").appendTo("#node-input-change");
@@ -552,11 +554,11 @@
                         $('#node-input-compareValue').typedInput('types',['re']);
                         $('#node-input-compareValue').typedInput('type','re');
                     } else {
-                        $('#node-input-compareValue').typedInput('types',['num']);
+                        $('#node-input-compareValue').typedInput('types',['num',halTypeState()]);
                         $('#node-input-compareValue').typedInput('type','num');                        
                     }
                 } else {
-                    $('#node-input-compareValue').typedInput('types',['str','num','json']);
+                    $('#node-input-compareValue').typedInput('types',['str','num','json',halTypeState()]);
                 }
             });
         },

--- a/core/event.js
+++ b/core/event.js
@@ -11,6 +11,7 @@ module.exports = function(RED) {
         this.change         = config.change;
         this.compareValue   = config.compareValue;
         this.compareType    = config.compareType;
+        this.compareSource  = config.compareSource || null;
         this.outputValue    = config.outputValue;
         this.outputType     = config.outputType;
         this.typeSel        = config.typeSel;
@@ -54,8 +55,26 @@ module.exports = function(RED) {
             'otherwise':function (a,b,c)    { return c === 0 }
         }, rules.COMPARE);
 
-        // Copy so per-node use can never mutate the shared converter table.
-        var convertTo = Object.assign({}, rules.CONVERTERS);
+        // Copy so per-node use can never mutate the shared converter table. `state` compares
+        // against another live reading rather than a constant, resolved at trigger time so the
+        // two sides cannot disagree because one was stored earlier.
+        var convertTo = Object.assign({
+            'state': function () {
+                var spec = node.compareSource;
+                if (!spec) { return undefined; }
+                if (spec.src === 'group') {
+                    if (!node.eventHandler || typeof node.eventHandler.readGroup !== 'function') { return undefined; }
+                    if (spec.groupFunction) {
+                        var read = node.eventHandler.readGroup(spec.group, spec.groupFunction);
+                        return read ? read.value : undefined;
+                    }
+                    var rec = node.eventHandler.getGroupState(spec.group);
+                    return rec ? rec.state : undefined;
+                }
+                var thing = RED.nodes.getNode(spec.thing);
+                return (thing && thing.state) ? thing.state[spec.item] : undefined;
+            }
+        }, rules.CONVERTERS);
 
         function showState() {
             var now = Date.now();
@@ -205,7 +224,9 @@ module.exports = function(RED) {
                 }
                 if (node.change == '2' && typeof event.laststate == 'undefined') { return; }
                 if (node.change == '1' && event.state === event.laststate) { return; }
-                if (compare[node.operator](event.state,convertTo[node.compareType](node.compareValue),event.laststate)){
+                var cv = convertTo[node.compareType](node.compareValue);
+                if (node.compareType === 'state' && cv === undefined) { showState(); return; }
+                if (compare[node.operator](event.state,cv,event.laststate)){
                     if (node.delay) {
                         if (typeof eventDelay[thingid] != 'undefined') {
                             if (node.delayExtend) {

--- a/core/gate.html
+++ b/core/gate.html
@@ -33,6 +33,10 @@
     <li><strong>Name</strong>: Node name.</li> 
     <li><strong>Event handler</strong>: Only needed when a rule reads a <i>Group</i>; it is where group values live.</li>
     <li><strong>Rules</strong>: Add one or more conditions to be met. A rule's source can be a Thing, a Thing set by <code>msg.thing.id</code>, or a <i>Group</i> that has been given a <b>Value</b> on the Event handler's Groups tab. A group carries one aggregated value, so it needs no Item.</li>
+    <li><strong>state</strong>: A value type that compares against another live reading rather than a
+    constant &mdash; another Thing's Item, or a Group with a function of its own, picked on the
+    <i>Compare</i> row. Both sides are read in the same pass, so they cannot disagree because one was
+    stored in a variable earlier.</li>
     <li><strong>No value</strong>: A rule whose source cannot be read — a missing Thing, or a group where no live member is reporting — does not match, rather than comparing against a stale or invented value.</li>
     <li><strong>TSU</strong>: Time since last update (in seconds)</li>
     <li><strong>TSC</strong>: Time since last change (in seconds)</li>
@@ -132,6 +136,7 @@
                         .appendTo(container)
                         .hide()
                     var rowRule = $('<div/>',{style:"margin-top:8px;"}).appendTo(container);
+                    var rowCmp  = $('<div/>',{style:"margin-top:8px;"}).appendTo(container).hide();
 
                     //Add labels
                     var labelName = $('<div/>',{style:"display:inline-block;text-align:left; width:80px; padding-right:10px; box-sizing:border-box;",class:"fa fa-microchip"})
@@ -155,6 +160,14 @@
                     var labelRule = $('<div/>',{style:"display:inline-block;text-align:left; width:80px; padding-right:10px; box-sizing:border-box;"})
                         .appendTo(rowRule)
                         .append(' Rule')   
+                    $('<div/>',{style:"display:inline-block;text-align:left; width:80px; padding-right:10px; box-sizing:border-box;",class:"fa fa-sitemap"})
+                        .appendTo(rowCmp).append(' Compare')
+                    var cmpSel  = $('<select/>',{class:"node-input-rule-cmp",style:"width:calc(55% - 60px)"}).appendTo(rowCmp);
+                    var cmpItem = $('<select/>',{class:"node-input-rule-cmpitem",style:"width:calc(45% - 60px); margin-left:4px;"}).appendTo(rowCmp);
+                    var cmpFn   = $('<select/>',{class:"node-input-rule-cmpfn",style:"width:calc(45% - 60px); margin-left:4px;"}).appendTo(rowCmp);
+                    var syncCmp = halFillSourcePicker(cmpSel, cmpItem, cmpFn, thingsList, groupsList, rule.cmp);
+                    cmpSel.change(syncCmp);
+                    syncCmp();
 
                     var thingsField = $('<select/>',{class:"node-input-rule-thing",style:"width:calc(100% - 110px)"}).appendTo(rowName);
                     var typesField = $('<select/>',{class:"node-input-rule-type",style:"width:calc(100% - 110px)"}).appendTo(rowTypes);
@@ -317,12 +330,20 @@
                     }
 
                     //Add comparison value field
+                    // Also on the type select itself: choosing 'state' is a change of type, not
+                    // of operator, and the row has to appear then too.
                     var valueField = $('<input/>',{class:"node-input-rule-value",type:"text"})
                         .appendTo(rowRule)
                         .typedInput({
                             default:'num'
                         });
                     
+                    // typedInput fires a change on its element when the *type* is switched, which
+                    // is how choosing 'state' reveals the row without touching the operator.
+                    valueField.on('change', function() {
+                        rowCmp.toggle(valueField.typedInput('type') === 'state');
+                    });
+
                     //Show/Hide value field
                     operatorField.change( function() {
                         var type = $(this).children("option:selected").val();
@@ -340,19 +361,21 @@
                         } else {
                             valueField.typedInput('show');
                         }
+                        // The compare row belongs to the value, so it follows the value's type.
+                        setTimeout(function() { rowCmp.toggle(valueField.typedInput('type') === 'state'); }, 0);
                         if (type == "regex" || type == "lt" || type == "lte" || type == "gt" || type == "gte") {
                             if (type == "regex") {
                                 valueField.typedInput('types',['re']);
                                 valueField.typedInput('type','re');
                             } else {
-                                valueField.typedInput('types',['msg','flow','global','num','env']);
+                                valueField.typedInput('types',['msg','flow','global','num','env',halTypeState()]);
                                 valueField.typedInput('type',rule.ct);                        
                             }
                         } else if (type == "last_update_gte" || type == "last_update_lte" || type == "last_change_gte" || type == "last_change_lte") {
                             valueField.typedInput('types',['num','msg','flow','global','env']);
                             valueField.typedInput('type',rule.ct);
                         } else {
-                            valueField.typedInput('types',['msg','flow','global','str','num','env']);
+                            valueField.typedInput('types',['msg','flow','global','str','num','env',halTypeState()]);
                             valueField.typedInput('type',rule.ct);
                         }
                     });
@@ -427,6 +450,11 @@
                 var type  = rule.find(".node-input-rule-value").typedInput('type');
 
                 var r = {thing:thing, thingtype:thingtype, item:item, operator:operator, value:value, type:type};
+                if (type === 'state') {
+                    r.cmp = halReadSourcePicker(rule.find(".node-input-rule-cmp"),
+                                                rule.find(".node-input-rule-cmpitem"),
+                                                rule.find(".node-input-rule-cmpfn"));
+                }
                 if (savedGroups[thing]) {
                     r.category = 'hal2Group';
                     r.function = rule.find(".node-input-rule-function option:selected").val() || '';

--- a/core/gate.html
+++ b/core/gate.html
@@ -136,7 +136,12 @@
                         .appendTo(container)
                         .hide()
                     var rowRule = $('<div/>',{style:"margin-top:8px;"}).appendTo(container);
+                    // Thing and item on separate rows, as everything above them in this rule.
                     var rowCmp  = $('<div/>',{style:"margin-top:8px;"}).appendTo(container).hide();
+                    var rowCmpItem = $('<div/>',{style:"margin-top:8px;"}).appendTo(container).hide();
+                    var rowCmpTip = $('<div/>', { class: "form-tips",
+                        style: "margin-top:8px; margin-left:80px; width:calc(100% - 110px); max-width:none; box-sizing:border-box; white-space:normal;" })
+                        .appendTo(container).hide();
 
                     //Add labels
                     var labelName = $('<div/>',{style:"display:inline-block;text-align:left; width:80px; padding-right:10px; box-sizing:border-box;",class:"fa fa-microchip"})
@@ -162,12 +167,26 @@
                         .append(' Rule')   
                     $('<div/>',{style:"display:inline-block;text-align:left; width:80px; padding-right:10px; box-sizing:border-box;",class:"fa fa-sitemap"})
                         .appendTo(rowCmp).append(' Compare')
-                    var cmpSel  = $('<select/>',{class:"node-input-rule-cmp",style:"width:calc(55% - 60px)"}).appendTo(rowCmp);
-                    var cmpItem = $('<select/>',{class:"node-input-rule-cmpitem",style:"width:calc(45% - 60px); margin-left:4px;"}).appendTo(rowCmp);
-                    var cmpFn   = $('<select/>',{class:"node-input-rule-cmpfn",style:"width:calc(45% - 60px); margin-left:4px;"}).appendTo(rowCmp);
-                    var syncCmp = halFillSourcePicker(cmpSel, cmpItem, cmpFn, thingsList, groupsList, rule.cmp);
-                    cmpSel.change(syncCmp);
-                    syncCmp();
+                    var cmpSel  = $('<select/>',{class:"node-input-rule-cmp",style:"width:calc(100% - 110px)"}).appendTo(rowCmp);
+                    var labelCmpItem = $('<div/>',{style:"display:inline-block;text-align:left; width:80px; padding-right:10px; box-sizing:border-box;",class:"fa fa-sitemap"})
+                        .appendTo(rowCmpItem).append(' Item');
+                    var cmpItem = $('<select/>',{class:"node-input-rule-cmpitem",style:"width:calc(100% - 110px)"}).appendTo(rowCmpItem);
+                    var cmpFn   = $('<select/>',{class:"node-input-rule-cmpfn",style:"width:calc(100% - 110px)"}).appendTo(rowCmpItem);
+                    var syncCmp = halFillSourcePicker(cmpSel, cmpItem, cmpFn, thingsList, groupsList, rule.cmp,
+                        function(text) { rowCmpTip.text(text).toggle(!!text && rowCmp.is(':visible')); });
+                    // One place decides the whole block, so the rows cannot drift apart.
+                    function showCmp(on) {
+                        rowCmp.toggle(on);
+                        rowCmpItem.toggle(on);
+                        rowCmpTip.toggle(on && !!rowCmpTip.text());
+                    }
+                    cmpSel.change(function() {
+                        var isGroup = (cmpSel.val() || '').indexOf('g:') === 0;
+                        labelCmpItem.text(isGroup ? ' Value' : ' Item')
+                            .attr('class', isGroup ? 'fa fa-calculator' : 'fa fa-sitemap');
+                        syncCmp();
+                    });
+                    cmpSel.trigger('change');
 
                     var thingsField = $('<select/>',{class:"node-input-rule-thing",style:"width:calc(100% - 110px)"}).appendTo(rowName);
                     var typesField = $('<select/>',{class:"node-input-rule-type",style:"width:calc(100% - 110px)"}).appendTo(rowTypes);
@@ -341,7 +360,7 @@
                     // typedInput fires a change on its element when the *type* is switched, which
                     // is how choosing 'state' reveals the row without touching the operator.
                     valueField.on('change', function() {
-                        rowCmp.toggle(valueField.typedInput('type') === 'state');
+                        showCmp(valueField.typedInput('type') === 'state');
                     });
 
                     //Show/Hide value field
@@ -362,7 +381,10 @@
                             valueField.typedInput('show');
                         }
                         // The compare row belongs to the value, so it follows the value's type.
-                        setTimeout(function() { rowCmp.toggle(valueField.typedInput('type') === 'state'); }, 0);
+                        setTimeout(function() {
+                            showCmp(type !== 'true' && type !== 'false' &&
+                                    valueField.typedInput('type') === 'state');
+                        }, 0);
                         if (type == "regex" || type == "lt" || type == "lte" || type == "gt" || type == "gte") {
                             if (type == "regex") {
                                 valueField.typedInput('types',['re']);
@@ -392,7 +414,7 @@
                         valueField.typedInput('value', rule.value === undefined ? '' : rule.value);
                         if (rule.type) { valueField.typedInput('type', rule.type); }
                     }
-                    rowCmp.toggle(valueField.typedInput('type') === 'state');
+                    showCmp(valueField.typedInput('type') === 'state');
                     thingsField.trigger('change');
                     itemsField.trigger('change');
                 },

--- a/core/gate.html
+++ b/core/gate.html
@@ -369,14 +369,11 @@
                                 valueField.typedInput('type','re');
                             } else {
                                 valueField.typedInput('types',['msg','flow','global','num','env',halTypeState()]);
-                                valueField.typedInput('type',rule.ct);                        
                             }
                         } else if (type == "last_update_gte" || type == "last_update_lte" || type == "last_change_gte" || type == "last_change_lte") {
                             valueField.typedInput('types',['num','msg','flow','global','env']);
-                            valueField.typedInput('type',rule.ct);
                         } else {
                             valueField.typedInput('types',['msg','flow','global','str','num','env',halTypeState()]);
-                            valueField.typedInput('type',rule.ct);
                         }
                     });
 
@@ -384,11 +381,18 @@
                     if (Object.keys(rule).length !== 0) {
                         thingsField.val(rule.thing);
                         operatorField.val(rule.operator);
-                        valueField.typedInput('value',rule.value);
-                        valueField.typedInput('type',rule.type);
                         if (typeof rule.thingtype !== 'undefined') { typesField.val(rule.thingtype); }
                     }
+                    // The operator decides which types the value field offers, so it has to run
+                    // before the saved type is put back: typedInput drops a type that is not in
+                    // the current list, and the list here starts as Node-RED's built-in set,
+                    // which has no 'state'. Restoring first lost every saved state comparison.
                     operatorField.trigger('change');
+                    if (Object.keys(rule).length !== 0) {
+                        valueField.typedInput('value', rule.value === undefined ? '' : rule.value);
+                        if (rule.type) { valueField.typedInput('type', rule.type); }
+                    }
+                    rowCmp.toggle(valueField.typedInput('type') === 'state');
                     thingsField.trigger('change');
                     itemsField.trigger('change');
                 },

--- a/core/gate.js
+++ b/core/gate.js
@@ -9,52 +9,61 @@ module.exports = function(RED) {
             'flow':     function (value)    { return node.context().flow.get(value); },
             'global':   function (value)    { return node.context().global.get(value); },
             'env':      function (value)    { return process.env[value]; },
-            'msg':      function (value,msg)    { return RED.util.getMessageProperty(msg,value); }
+            'msg':      function (value,msg)    { return RED.util.getMessageProperty(msg,value); },
+            // Both sides read in the same pass, so they cannot disagree because one was stored
+            // earlier — which is the whole reason this type exists.
+            'state':    function (value,msg,rule) {
+                var read = rule && rule.cmp ? readSource(rule.cmp) : null;
+                return read ? read.state : undefined;
+            }
         }, rules.CONVERTERS);
 
         //a=state, b=comparison value
         var compare = rules.COMPARE;
 
-        // The state a rule compares against, plus the timestamps the last_* operators need.
-        // A thing keeps these per item; a group keeps one set for its whole aggregated value.
-        function sourceOf(rule) {
-            if (rule.category === 'hal2Group') {
-                if (!node.eventHandler || typeof node.eventHandler.getGroupState !== 'function') {
-                    node.warn('Rule skipped: a group rule needs an event handler on this node');
+        // One reading, from a spec that says where to look: { src, thing, item, group,
+        // groupFunction } — the shape hal2Bayes uses for its steps, so both sides of a rule and
+        // all three rule nodes describe a source the same way. Returns null when it cannot be
+        // read, which every caller treats as "no match" rather than as a value.
+        //
+        // `dynamic` is only meaningful on the left: the right-hand side of a comparison names
+        // the thing it means.
+        function readSource(spec) {
+            if (spec.src === 'group') {
+                if (!node.eventHandler || typeof node.eventHandler.readGroup !== 'function') {
+                    node.warn('Rule skipped: a group source needs an event handler on this node');
                     return null;
                 }
-                // Each rule reads the group its own way; without a function of its own it
-                // falls back to whatever the group reports by default.
-                if (rule.function) {
-                    var read = node.eventHandler.readGroup(rule.thing, rule.function);
-                    if (!read || read.value === undefined) { return null; }
-                    // The engine tracks a record per function, so these are the real
-                    // timestamps for this function rather than the default's or a derived
-                    // guess — which could not be right for min, max or anyTrue.
-                    return { state: read.value, laststate: read.laststate,
-                             last_update: read.last_update, last_change: read.last_change };
+                if (spec.groupFunction) {
+                    var gread = node.eventHandler.readGroup(spec.group, spec.groupFunction);
+                    if (!gread || gread.value === undefined) { return null; }
+                    return { state: gread.value, laststate: gread.laststate,
+                             last_update: gread.last_update, last_change: gread.last_change };
                 }
-                var rec = node.eventHandler.getGroupState(rule.thing);
-                // No record, or no live member reporting: the rule has nothing to compare
-                // and does not match, rather than matching against a stale or invented value.
-                if (!rec || rec.state === undefined) { return null; }
-                return { state: rec.state, laststate: rec.laststate,
-                         last_update: rec.last_update, last_change: rec.last_change };
+                var grec = node.eventHandler.getGroupState(spec.group);
+                if (!grec || grec.state === undefined) { return null; }
+                return { state: grec.state, laststate: grec.laststate,
+                         last_update: grec.last_update, last_change: grec.last_change };
+            }
+            var t;
+            try { t = RED.nodes.getNode(spec.thing); }
+            catch (error) { return null; }
+            if (!t || !t.state || !t.state.hasOwnProperty(spec.item)) { return null; }
+            return { state: t.state[spec.item], laststate: t.laststate[spec.item],
+                     last_update: t.heartbeat[spec.item], last_change: t.last_change[spec.item] };
+        }
+
+        // The left-hand side of a rule, expressed as a spec and read the same way. `dynamic`
+        // resolves to a thing named by the message; everything else is a plain source.
+        function sourceOf(rule) {
+            if (rule.category === 'hal2Group') {
+                return readSource({ src: 'group', group: rule.thing, groupFunction: rule.function });
             }
             var id = (rule.thing == 'dynamic')
                 ? common.thingIdFromMsg(RED,node,rule.thingtype,msg)
                 : rule.thing;
             if (typeof id == 'undefined') { return null; }
-            var thing;
-            try {
-                thing = RED.nodes.getNode(id);
-            } catch (error) {
-                console.log('Error: '+error.message);
-            }
-            if (typeof thing == 'undefined' || thing === null) { return null; }
-            if (!thing.state || !thing.state.hasOwnProperty(rule.item)) { return null; }
-            return { state: thing.state[rule.item], laststate: thing.laststate[rule.item],
-                     last_update: thing.heartbeat[rule.item], last_change: thing.last_change[rule.item] };
+            return readSource({ src: 'thing', thing: id, item: rule.item });
         }
 
         var ruleMatch = 0;
@@ -63,7 +72,10 @@ module.exports = function(RED) {
             var src = sourceOf(rule);
             if (src === null) { continue; }      // unresolvable source never matches
 
-            var cv = convertTo[rule.type](rule.value,msg);
+            var cv = convertTo[rule.type](rule.value,msg,rule);
+            // An unreadable comparison source is not a value of undefined to compare against;
+            // the rule simply has nothing to say.
+            if (rule.type === 'state' && cv === undefined) { continue; }
 
             if (rule.operator.includes('last_')) {
                 let now = Date.now();

--- a/lib/bayes.js
+++ b/lib/bayes.js
@@ -99,7 +99,14 @@ function createBayes(cfg) {
         };
     }
 
-    function conditionMatches(step, raw) {
+    // resolveState is threaded in because a 'state' comparison reads a second source: the spec
+    // in step.cmp is itself a step, so the same resolver serves both sides and the right-hand
+    // side gets thing/group/flow/global/env for free.
+    //
+    // Some paths reach here without a resolver — completeStep is called without one when the
+    // sequence advances on an edge alone. A 'state' comparison then cannot be evaluated, and
+    // joins the rule below: a condition that cannot be evaluated has not matched.
+    function conditionMatches(step, raw, resolveState) {
         const cmp = COMPARE[step.operator];
         if (!cmp) { return false; }
         if (step.operator === 'true' || step.operator === 'false') { return cmp(raw); }
@@ -108,7 +115,15 @@ function createBayes(cfg) {
         // where COMPARE.regex calls b.test — and one bad rule must not take the whole
         // evaluation down with it. A condition that cannot be evaluated has not matched.
         try {
-            const b = CONVERTERS[step.valueType || 'str'](step.value);
+            let b;
+            if (step.valueType === 'state') {
+                if (!step.cmp || !resolveState) { return false; }
+                b = resolveState(step.cmp);
+                // Nothing to compare against is not a comparison against undefined.
+                if (b === undefined) { return false; }
+            } else {
+                b = CONVERTERS[step.valueType || 'str'](step.value);
+            }
             return cmp(raw, b);
         } catch (e) { return false; }
     }
@@ -122,8 +137,8 @@ function createBayes(cfg) {
     // from it. A condition found true with no edge on record — true while the node was down,
     // or on the very first evaluation — starts its clock now rather than counting as held: a
     // hold that has not been observed has not been observed.
-    function conditionHolds(rule, step, index, raw, now) {
-        const matched = conditionMatches(step, raw);
+    function conditionHolds(rule, step, index, raw, now, resolveState) {
+        const matched = conditionMatches(step, raw, resolveState);
         if (step.pattern !== 'held') { return matched; }
         const key = stepKey(rule.id, index);
         if (!matched) { return false; }
@@ -175,7 +190,7 @@ function createBayes(cfg) {
         // for sensors that report late.
         if (next.pattern === 'is' || next.pattern === 'isOrBecomes' || next.pattern === 'held') {
             const raw = resolveState ? resolveState(next) : undefined;
-            if (conditionHolds(rule, next, f.stepIndex, raw, doneAt)) {
+            if (conditionHolds(rule, next, f.stepIndex, raw, doneAt, resolveState)) {
                 completeStep(rule, f, doneAt, fired, resolveState);
                 return;
             }
@@ -234,7 +249,7 @@ function createBayes(cfg) {
                 const step = rule.steps[hit.stepIndex];
                 const key = stepKey(rule.id, hit.stepIndex);
 
-                const matched   = conditionMatches(step, raw);
+                const matched   = conditionMatches(step, raw, resolveState);
                 const prev      = S.lastMatch[key];
                 const isRising  = matched && prev !== true;
                 const isFalling = !matched && prev === true;
@@ -265,7 +280,7 @@ function createBayes(cfg) {
                 // Re-check its level here so "now or soon" means that for them too.
                 const step = rule.steps[f.stepIndex];
                 if (step && f.stepIndex > 0 && (step.pattern === 'isOrBecomes' || step.pattern === 'held') && resolveState) {
-                    if (conditionHolds(rule, step, f.stepIndex, resolveState(step), now)) {
+                    if (conditionHolds(rule, step, f.stepIndex, resolveState(step), now, resolveState)) {
                         completeStep(rule, f, now, fired, resolveState);
                         continue;
                     }
@@ -309,7 +324,7 @@ function createBayes(cfg) {
                 let holds = true;
                 for (let i = 0; i < rule.steps.length && holds; i++) {
                     const v = i === 0 ? raw : resolveState(rule.steps[i]);
-                    holds = conditionHolds(rule, rule.steps[i], i, v, now);
+                    holds = conditionHolds(rule, rule.steps[i], i, v, now, resolveState);
                     // Name the step that failed: with several conditions, "which one" is the
                     // whole question.
                     if (!holds && rule.steps.length > 1) { e.failedStep = i + 1; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-hal2",
-      "version": "2.11.4",
+      "version": "2.11.5",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.20.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.11.5",
+  "version": "2.12.0",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hal2",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "description": "A set of nodes to help with basic home automation logic, now with MCP server support",
   "repository": {
     "type": "git",

--- a/resources/hal.js
+++ b/resources/hal.js
@@ -77,6 +77,71 @@ function halGroupFunctionTip(haType, chosen, stray, strayNote) {
         : 'This group has no default for its HAType — pick a function or it reads as no value.';
 }
 
+// The custom typedInput type for comparing against another live reading. The value the
+// typedInput itself holds is unused — the source is picked in its own row, because a flat list
+// of every thing item and group function runs to several hundred entries.
+function halTypeState() {
+    return { value: "state", label: "state", icon: "fa fa-sitemap", hasValue: false };
+}
+
+// Fill a source picker pair: a thing/group select and, depending on which was chosen, an item
+// select or a group function select. `spec` is { src, thing, item, group, groupFunction } — the
+// shape hal2Bayes uses for its steps, so both sides of a rule describe a source the same way.
+// Returns the element set so the caller can show and hide them together.
+function halFillSourcePicker(sel, itemSel, fnSel, things, groups, spec) {
+    spec = spec || {};
+    sel.children().remove();
+    for (var g in groups) {
+        sel.append($("<option></option>").val('g:' + groups[g].id).text('Group - ' + groups[g].name));
+    }
+    for (var t in things) {
+        sel.append($("<option></option>").val('t:' + things[t].id).text(things[t].name));
+    }
+    var want = spec.src === 'group' ? 'g:' + spec.group : 't:' + spec.thing;
+    if (sel.find('option[value="' + want + '"]').length) { sel.val(want); }
+
+    return function sync() {
+        var val = sel.val() || '';
+        var isGroup = val.indexOf('g:') === 0;
+        var id = val.slice(2);
+        itemSel.toggle(!isGroup);
+        fnSel.toggle(isGroup);
+        if (isGroup) {
+            var grp = null;
+            for (var i in groups) { if (groups[i].id === id) { grp = groups[i]; } }
+            halFillGroupFunctions(fnSel, grp && grp.haType,
+                                  fnSel.val() || (spec.src === 'group' ? spec.groupFunction : '') || '');
+        } else {
+            var keep = (spec.src !== 'group' && spec.thing === id) ? spec.item : itemSel.val();
+            halFillStatusItems(itemSel, id, keep);
+        }
+    };
+}
+
+// The status-capable items of a thing, for a source picker. Mirrors what every node's own item
+// select already does; kept here so the compare side and the rule side agree on what is readable.
+function halFillStatusItems(sel, thingId, keep) {
+    sel.children().remove();
+    var thing = thingId ? RED.nodes.node(thingId) : null;
+    var tt = null;
+    try { tt = thing ? RED.nodes.node(thing.thingType) : null; } catch (e) {}
+    if (tt && Array.isArray(tt.items)) {
+        tt.items.forEach(function (it) {
+            if (halStatusItem(it)) { sel.append($("<option></option>").val(it.id).text(it.name)); }
+        });
+    }
+    if (keep) { sel.val(keep); }
+}
+
+// Read a source picker back into the spec shape.
+function halReadSourcePicker(sel, itemSel, fnSel) {
+    var val = sel.val() || '';
+    if (val.indexOf('g:') === 0) {
+        return { src: 'group', group: val.slice(2), groupFunction: fnSel.val() || '' };
+    }
+    return { src: 'thing', thing: val.slice(2), item: itemSel.val() || '' };
+}
+
 function halTypeMQTT() {
     return {
         value: "mqtt",

--- a/resources/hal.js
+++ b/resources/hal.js
@@ -84,11 +84,42 @@ function halTypeState() {
     return { value: "state", label: "state", icon: "fa fa-sitemap", hasValue: false };
 }
 
+// The line under a source picker: what a group's function means, or the notes on the thing and
+// item that were picked. The primary picker in every node already says this much about its
+// source, so the compare side says it too — worded here rather than three times, because the
+// complaint that started this was that the three nodes did not agree.
+function halSourceTip(sel, itemSel, fnSel, groups) {
+    var val = sel.val() || '';
+    if (val.indexOf('g:') === 0) {
+        var id = val.slice(2), grp = null;
+        for (var i in groups) { if (groups[i].id === id) { grp = groups[i]; } }
+        var ga = (typeof window !== 'undefined') && window.hal2GroupAggregate;
+        var chosen = fnSel.val() || '';
+        var stray = !!chosen && ga && ga.functionsForHaType(grp && grp.haType).indexOf(chosen) < 0;
+        return halGroupFunctionTip(grp && grp.haType, chosen, stray,
+            'The saved function does not fit this group\'s members — this comparison will never match.');
+    }
+    var thing = val ? RED.nodes.node(val.slice(2)) : null;
+    if (!thing) { return ''; }
+    var out = [];
+    if (thing.notes) { out.push(thing.notes); }
+    var tt = null;
+    try { tt = RED.nodes.node(thing.thingType); } catch (e) {}
+    if (tt && Array.isArray(tt.items)) {
+        var itemId = itemSel.val();
+        tt.items.forEach(function (it) { if (it.id === itemId && it.notes) { out.push(it.notes); } });
+    }
+    return out.join(' \u00b7 ');
+}
+
 // Fill a source picker pair: a thing/group select and, depending on which was chosen, an item
 // select or a group function select. `spec` is { src, thing, item, group, groupFunction } — the
 // shape hal2Bayes uses for its steps, so both sides of a rule describe a source the same way.
 // Returns the element set so the caller can show and hide them together.
-function halFillSourcePicker(sel, itemSel, fnSel, things, groups, spec) {
+// `setTip` is optional: called with the line to show, or '' when there is nothing to say. A
+// callback rather than an element because the three editors lay their tip rows out differently —
+// a flex row in hal2Bayes, a form-tips block in the other two.
+function halFillSourcePicker(sel, itemSel, fnSel, things, groups, spec, setTip) {
     spec = spec || {};
     sel.children().remove();
     for (var g in groups) {
@@ -99,6 +130,11 @@ function halFillSourcePicker(sel, itemSel, fnSel, things, groups, spec) {
     }
     var want = spec.src === 'group' ? 'g:' + spec.group : 't:' + spec.thing;
     if (sel.find('option[value="' + want + '"]').length) { sel.val(want); }
+
+    function syncTip() { if (setTip) { setTip(halSourceTip(sel, itemSel, fnSel, groups)); } }
+    // The tip follows the item and the function too, not just the source: which item was picked
+    // decides which notes apply, and which function was picked is most of what the line says.
+    if (setTip) { itemSel.change(syncTip); fnSel.change(syncTip); }
 
     return function sync() {
         var val = sel.val() || '';
@@ -115,6 +151,7 @@ function halFillSourcePicker(sel, itemSel, fnSel, things, groups, spec) {
             var keep = (spec.src !== 'group' && spec.thing === id) ? spec.item : itemSel.val();
             halFillStatusItems(itemSel, id, keep);
         }
+        syncTip();
     };
 }
 

--- a/test/bayes.test.js
+++ b/test/bayes.test.js
@@ -1126,3 +1126,63 @@ describe('a condition that must have held', function() {
             'twenty minutes of holding survived the restart');
     });
 });
+
+describe('comparing one source against another', function() {
+    // Both sides read in the same pass, so they cannot disagree because one was stored
+    // earlier — the staleness that a flow variable between them invites.
+    const cmpRule = (id, lr, cmp) => ({ id, lr, halfLifeMs: null, steps: [
+        step('is', { thing: 'a', operator: 'gt', valueType: 'state', value: '', cmp: cmp })
+    ]});
+    const OTHER = { src: 'thing', thing: 'b', item: 'b' };
+
+    it('compares against the other source as it reads right now', function() {
+        const b = createBayes(cfgOf({ rules: [cmpRule('r', 10, OTHER)] }));
+        const state = { a: 25, b: 20 };
+        const R = stateOf(state);
+
+        assert.strictEqual(active(b.evaluate(R, 0)).length, 1, '25 > 20');
+        state.b = 30;
+        assert.strictEqual(active(b.evaluate(R, MIN)).length, 0, 'the other side moved past it');
+        state.b = 10;
+        assert.strictEqual(active(b.evaluate(R, 2 * MIN)).length, 1, 'and back');
+    });
+
+    it('follows a change on either side within the same evaluation', function() {
+        // Nothing is stored between them, so there is no window where the two disagree.
+        const b = createBayes(cfgOf({ rules: [cmpRule('r', 10, OTHER)] }));
+        const state = { a: 25, b: 20 };
+        const R = stateOf(state);
+        assert.strictEqual(active(b.evaluate(R, 0)).length, 1);
+        state.a = 15;
+        assert.strictEqual(active(b.evaluate(R, MIN)).length, 0, 'left side moved');
+    });
+
+    it('does not match when the comparison source cannot be read', function() {
+        const b = createBayes(cfgOf({ rules: [
+            cmpRule('bad', 10, { src: 'thing', thing: 'gone', item: 'gone' }),
+            contRule('good', 10, { thing: 'c' })
+        ]}));
+        const r = b.evaluate(stateOf({ a: 25, c: true }), 0);
+        assert.strictEqual(byId(r, 'bad').status, 'condition-false', 'nothing to compare against');
+        assert.strictEqual(byId(r, 'good').status, 'contributing', 'and the neighbours still run');
+    });
+
+    it('does not match — and does not throw — with no resolver available', function() {
+        // completeStep advances a sequence on an edge alone and passes no resolver. A state
+        // comparison cannot be evaluated there, and one unevaluable step must not take the
+        // whole evaluation with it.
+        const b = createBayes(cfgOf({ rules: [cmpRule('r', 10, OTHER)] }));
+        assert.doesNotThrow(function() { b.evaluate(function() { return 25; }, 0); });
+        const missingSpec = createBayes(cfgOf({ rules: [cmpRule('r', 10, null)] }));
+        assert.strictEqual(active(missingSpec.evaluate(stateOf({ a: 25 }), 0)).length, 0);
+    });
+
+    it('leaves the ordinary value types alone', function() {
+        const b = createBayes(cfgOf({ rules: [
+            { id: 'num', lr: 10, halfLifeMs: null,
+              steps: [step('is', { thing: 'a', operator: 'gt', value: '20', valueType: 'num' })] }
+        ]}));
+        assert.strictEqual(active(b.evaluate(stateOf({ a: 25 }), 0)).length, 1);
+        assert.strictEqual(active(b.evaluate(stateOf({ a: 15 }), MIN)).length, 0);
+    });
+});


### PR DESCRIPTION
Every rule in hal2 compared one source against a **constant**: a number, a string, or a variable read at evaluation time. Comparing two live readings was not expressible, and the workaround cost correctness.

The case that exposed it: a Gate answering *"is everyone who is home asleep?"* by comparing `countTrue` of the people-home group against `flow.phones_charging`, a count a change node had stored earlier. The two sides are then sampled at different moments — someone comes home, the variable has not caught up, and the equality silently fails. It is self-correcting, and therefore the kind of wrong that never gets reported.

Reading both sides at evaluation time makes the staleness impossible, and removes the change node, the variable, and the discipline of remembering to recompute it from *both* directions.

## What it looks like

A new value type, `state`, in `hal2Gate`, `hal2Event` and `hal2Bayes`. Choosing it reveals a second source picker beside the value:

```
Thing:    Fredrik & Peggy Hemma
Value:    count true
Rule:     ==  [state]
Compare:  Telefoner som laddar   count true
```

Groups on the right-hand side are the point rather than a bonus — the case that prompted this compares two group counts, and `readGroup()` already computes any function on demand.

A flat list was not an option: this location has 281 readable items and roughly a hundred group/function combinations. The picker is a source selector of the same shape as the one the rule already uses.

## Design

One spec shape everywhere — `{ src, thing, item, group, groupFunction }`, which is what `hal2Bayes` already used for its steps. Both sides of a rule and all three nodes describe a source the same way, and in Bayes the comparison side gets thing, group, flow, global and env for free, because `resolveState` already handles them.

Gate's `sourceOf` turned out to *be* the resolver already, minus a name. Extracted as `readSource(spec)` and used for both sides.

**Bayes was the sensitive one.** `conditionMatches` was pure, and the resolver had to be threaded through it and `conditionHolds` — five call sites. Two of them are reachable without a resolver, where a state comparison cannot be evaluated; it returns `false` there, joining the existing rule that a condition which cannot be evaluated has not matched. There is a test for exactly that path, because one unevaluable step taking an entire Bayes evaluation with it is the failure this change could have introduced.

`state` is offered only where comparing values makes sense — not for `true`/`false`, `regex`, or Gate's `last_*` operators, which compare against a duration.

## Editor fixes found while testing this

- **The operator handler is the last writer of the value field's type list.** In Event and Bayes it rewrote the list on every operator change and at construction, without `state`, so offering the type anywhere else was decoration.
- **Gate's value field is constructed with no types list**, so it starts with Node-RED's built-in set, which has no `state`. The saved type was restored before the operator handler installed the real list, and typedInput silently drops a type it does not offer — every saved state comparison came back as something else.
- Removed three reads of `rule.ct` in Gate, which is assigned nowhere; with an undefined argument typedInput's `type()` is a getter, so they did nothing while looking like they preserved the type.
- The compare picker now presents its source the way the primary picker does: thing and item on separate rows in Event and Gate, one row in line 1's proportions in Bayes, and a tip line saying what a group's function means or what notes the thing and item carry. That tip moved into `halFillSourcePicker` rather than being written three times.

## Out of scope

- **Arithmetic between sources** (`a > b + 2`). The comparison is against the other reading as it is; a derived value still belongs in a flow.
- **`last_*` against another source.** Those compare against a duration, and "changed longer ago than that one" is a different feature with its own questions.

## Verification

329 tests passing; clean restart with no `[error]` in the log. Verified live in the editor across all three nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)